### PR TITLE
docs: align TradingView payload fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Konzeptübersicht
 
-- **Signalquelle (TradingView)**: TradingView sendet Kauf-/Verkaufssignale via Webhook mit standardisiertem JSON-Payload (Symbol, Richtung, Confidence, Zeitstempel, Positionsgröße, Stop/Take-Profit).
+- **Signalquelle (TradingView)**: TradingView sendet Kauf-/Verkaufssignale via Webhook mit standardisiertem JSON-Payload (Symbol, Aktion, Confidence, Zeitstempel, Menge (`quantity`), Stop-Loss/Take-Profit sowie optional Margin-Modus und Hebel).
 - **Server/Backend**:
   - Empfang und Verifizierung des Webhooks (Signaturprüfung, Rate Limits).
   - Event-Pipeline (Message-Queue) zur Entkopplung: `signals.raw` → `signals.validated` → `orders.executed`.

--- a/docs/installation_checklist.md
+++ b/docs/installation_checklist.md
@@ -81,13 +81,17 @@ Diese Liste fasst alle benötigten Konten, Tools und Installationsschritte für 
   ```json
   {
     "symbol": "BTCUSDT",
-    "direction": "buy",
+    "action": "buy",
     "confidence": 0.9,
-    "size": 0.01,
+    "timestamp": "2024-03-18T12:34:56Z",
+    "quantity": 0.01,
     "stop_loss": 26000,
-    "take_profit": 28000
+    "take_profit": 28000,
+    "leverage": 3,
+    "margin_mode": "isolated"
   }
   ```
+  - `action` erwartet `buy` oder `sell`, `quantity` die zu handelnde Menge. `timestamp` muss ein ISO-8601-Wert (UTC empfohlen) sein. `stop_loss` und `take_profit` sind optionale Preislevel, `leverage` und `margin_mode` (``isolated``/``cross``) steuern die Positionsparameter.
 
 ## 6. Telegram-Bot Konfiguration
 


### PR DESCRIPTION
## Summary
- update the TradingView webhook example to match the TradingViewSignal schema
- clarify the surrounding checklist text to reference the current field names
- adjust the README overview so it describes the new payload structure consistently

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68e219c8a75c832d99e63077f6af2417