### PR TITLE
Inject settings defaults into signal ingestion

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -37,9 +37,10 @@ def get_publisher(request: Request) -> InMemoryPublisher:
 async def get_signal_service(
     session: AsyncSession = Depends(get_db_session),
     publisher: InMemoryPublisher = Depends(get_publisher),
+    settings: Settings = Depends(get_settings),
 ) -> SignalService:
     repository = SignalRepository(session)
-    return SignalService(repository, publisher)
+    return SignalService(repository, publisher, settings)
 
 
 @app.get("/health")

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -12,6 +12,8 @@ from backend.app import config
 def _clear_settings_cache(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setenv("TRADINGVIEW_WEBHOOK_TOKEN", "test-token")
     monkeypatch.setenv("DATABASE_URL", f"sqlite+aiosqlite:///{(tmp_path / 'test.db').as_posix()}")
+    monkeypatch.setenv("DEFAULT_MARGIN_MODE", "cross")
+    monkeypatch.setenv("DEFAULT_LEVERAGE", "7")
     config.get_settings.cache_clear()
 
 


### PR DESCRIPTION
## Summary
- inject the application settings into `SignalService` through FastAPI dependency wiring
- populate `Signal` leverage and margin fields with configured defaults when the webhook omits them
- extend webhook tests to cover default substitution and configure test-specific defaults

## Testing
- `pytest backend/tests/test_webhook.py` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68e21a5a4380832d9c47dba12888a41b