### PR TITLE
Add RabbitMQ publisher integration for validated signals

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,15 @@ BINGX_SUBACCOUNT_ID="optional-subaccount"
 DEFAULT_MARGIN_MODE="isolated"
 DEFAULT_LEVERAGE="5"
 
+# Message Broker (RabbitMQ example)
+BROKER_HOST="rabbitmq.example.com"
+BROKER_PORT="5672"
+BROKER_USERNAME="guest"
+BROKER_PASSWORD="guest"
+BROKER_VHOST="/"
+BROKER_EXCHANGE="signals"
+BROKER_VALIDATED_ROUTING_KEY="signals.validated"
+
 # Infrastructure (optional examples)
 POSTGRES_DSN="postgresql://user:password@db:5432/tvtelegrambingx"
 REDIS_URL="redis://redis:6379/0"

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -24,6 +24,16 @@ class Settings(BaseSettings):
     default_margin_mode: Literal["isolated", "cross"] = Field("isolated", alias="DEFAULT_MARGIN_MODE")
     default_leverage: int = Field(5, alias="DEFAULT_LEVERAGE", ge=1)
 
+    broker_host: Optional[str] = Field(default=None, alias="BROKER_HOST")
+    broker_port: int = Field(5672, alias="BROKER_PORT", ge=1, le=65535)
+    broker_username: str = Field("guest", alias="BROKER_USERNAME")
+    broker_password: str = Field("guest", alias="BROKER_PASSWORD")
+    broker_virtual_host: str = Field("/", alias="BROKER_VHOST")
+    broker_exchange: str = Field("signals", alias="BROKER_EXCHANGE")
+    broker_validated_routing_key: str = Field(
+        "signals.validated", alias="BROKER_VALIDATED_ROUTING_KEY"
+    )
+
 
 @lru_cache
 def get_settings() -> Settings:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "uvicorn[standard]>=0.29",
     "sqlmodel>=0.0.16",
     "pydantic-settings>=2.2",
+    "aio-pika>=9.4",
 ]
 
 [project.optional-dependencies]

--- a/docs/installation_checklist.md
+++ b/docs/installation_checklist.md
@@ -72,6 +72,10 @@ Diese Liste fasst alle benötigten Konten, Tools und Installationsschritte für 
   ```
 - [ ] **Lokale Entwicklung (SQLite + In-Memory Queue)**
   - Keine zusätzliche Installation notwendig; Konfiguration bereits in der FastAPI-App enthalten.
+- [ ] **Message-Broker für Produktion (RabbitMQ/Kafka)**
+  - Bevorzugt einen gemanagten Dienst nutzen (z. B. CloudAMQP, AWS MQ, Confluent Cloud) statt lokaler Docker-Container.
+  - Zugangsdaten als `BROKER_HOST`, `BROKER_PORT`, `BROKER_USERNAME`, `BROKER_PASSWORD`, `BROKER_VHOST`, `BROKER_EXCHANGE`, `BROKER_VALIDATED_ROUTING_KEY` in `.env` hinterlegen.
+  - Exchange/Topic `signals` (Topic-Typ) vorbereiten und `signals.validated` Routing-Key den Konsumenten zuweisen.
 
 ## 5. TradingView Webhook-Konfiguration
 


### PR DESCRIPTION
## Summary
- add message-broker configuration to the backend settings and sample environment file
- implement an aio-pika powered publisher and wire it into application startup while retaining the in-memory publisher for tests
- extend webhook tests with publisher overrides and document broker setup expectations in the README and installation checklist

## Testing
- pip install -e .[dev] *(fails: proxy prevents downloading build dependencies)*
- pytest *(fails: httpx missing because dependency installation failed)*

------
https://chatgpt.com/codex/tasks/task_e_68e21ebb7bd0832d8b74742363566492