### PR TITLE
Add Telegram bot integration and bot control endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@
 - **Reports**: Aggregierte PnL-, Volumen-, Trefferquoten-Reports (tages-/wochenweise).
 - **Status**: Budget, verfügbares Kapital, laufende Orders, Performance-Metriken, aktueller Margin/Hebel-Stand.
 - **Help**: Dokumentation der Befehle, FAQ, Link zu Support.
+- **Deployment ohne Docker**: Schritt-für-Schritt-Anleitung zum Betrieb als systemd- oder PM2-Service siehe [docs/telegram_bot_deployment.md](docs/telegram_bot_deployment.md).
 
 ## BingX-Integration
 

--- a/backend/app/repositories/bot_session_repository.py
+++ b/backend/app/repositories/bot_session_repository.py
@@ -35,6 +35,14 @@ class BotSessionRepository:
         await self._session.refresh(session)
         return session
 
+    async def save_context(self, session: BotSession, context: dict) -> BotSession:
+        """Persist updated context information for a session."""
+
+        session.context = context
+        await self._session.commit()
+        await self._session.refresh(session)
+        return session
+
     async def mark_completed(self, session: BotSession, status: BotSessionStatus = BotSessionStatus.COMPLETED) -> BotSession:
         session.status = status
         session.ended_at = datetime.now(timezone.utc)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -67,6 +67,25 @@ def _utcnow() -> datetime:
     return datetime.now(timezone.utc)
 
 
+class BotState(BaseModel):
+    """Current automation preferences for the trading bot."""
+
+    auto_trade_enabled: bool = False
+    manual_confirmation_required: bool = True
+    margin_mode: Literal["isolated", "cross"] = "isolated"
+    leverage: int = Field(1, ge=1)
+    updated_at: Optional[datetime] = None
+
+
+class BotSettingsUpdate(BaseModel):
+    """Partial update payload for :class:`BotState`."""
+
+    auto_trade_enabled: Optional[bool] = None
+    manual_confirmation_required: Optional[bool] = None
+    margin_mode: Optional[Literal["isolated", "cross"]] = None
+    leverage: Optional[int] = Field(default=None, ge=1)
+
+
 class User(SQLModel, table=True):
     """Represents a trading user interacting with the system."""
 

--- a/backend/app/services/bot_control_service.py
+++ b/backend/app/services/bot_control_service.py
@@ -1,0 +1,85 @@
+"""Service layer for Telegram bot interactions with backend state."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Iterable
+
+from ..config import Settings
+from ..repositories.bot_session_repository import BotSessionRepository
+from ..repositories.signal_repository import SignalRepository
+from ..repositories.user_repository import UserRepository
+from ..schemas import BotState, BotSettingsUpdate, Signal
+
+
+class BotControlService:
+    """Expose bot-facing operations for status management and reporting."""
+
+    def __init__(
+        self,
+        signal_repository: SignalRepository,
+        user_repository: UserRepository,
+        bot_session_repository: BotSessionRepository,
+        settings: Settings,
+    ) -> None:
+        self._signals = signal_repository
+        self._users = user_repository
+        self._bot_sessions = bot_session_repository
+        self._settings = settings
+
+    async def get_state(self) -> BotState:
+        session = await self._ensure_session()
+        return self._context_to_state(session.context)
+
+    async def update_state(self, update: BotSettingsUpdate) -> BotState:
+        session = await self._ensure_session()
+        current = self._context_to_state(session.context)
+        data = current.model_dump()
+        data.update(update.model_dump(exclude_unset=True))
+        data["updated_at"] = datetime.now(timezone.utc)
+        persisted = await self._bot_sessions.save_context(
+            session,
+            self._state_to_context(data.items()),
+        )
+        return self._context_to_state(persisted.context)
+
+    async def recent_signals(self, limit: int = 5) -> Iterable[Signal]:
+        """Return the most recent signals for reporting."""
+
+        return await self._signals.list_recent(limit)
+
+    async def _ensure_session(self):
+        user = await self._users.get_or_create_by_username(self._settings.trading_default_username)
+        return await self._bot_sessions.get_or_create_active_session(
+            user.id, self._settings.trading_default_session
+        )
+
+    def _context_to_state(self, context: dict | None) -> BotState:
+        data = context or {}
+        updated_at = data.get("updated_at")
+        if isinstance(updated_at, str):
+            try:
+                updated_at = datetime.fromisoformat(updated_at)
+            except ValueError:
+                updated_at = None
+        elif not isinstance(updated_at, datetime):
+            updated_at = None
+
+        return BotState(
+            auto_trade_enabled=bool(data.get("auto_trade_enabled", False)),
+            manual_confirmation_required=bool(data.get("manual_confirmation_required", True)),
+            margin_mode=str(data.get("margin_mode", self._settings.default_margin_mode)),
+            leverage=int(data.get("leverage", self._settings.default_leverage)),
+            updated_at=updated_at,
+        )
+
+    def _state_to_context(self, items: Iterable[tuple[str, object]]) -> dict:
+        context: dict[str, object] = {}
+        for key, value in items:
+            if key == "updated_at" and isinstance(value, datetime):
+                context[key] = value.astimezone(timezone.utc).replace(microsecond=0).isoformat()
+            else:
+                context[key] = value
+        return context
+
+
+__all__ = ["BotControlService"]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -11,6 +11,8 @@ dependencies = [
     "aio-pika>=9.4",
     "asyncpg>=0.29",
     "alembic>=1.13",
+    "aiogram>=3.5",
+    "httpx>=0.27",
 ]
 
 [project.optional-dependencies]

--- a/backend/tests/test_bot_api.py
+++ b/backend/tests/test_bot_api.py
@@ -1,0 +1,63 @@
+from datetime import datetime, timezone
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_bot_status_defaults(client):
+    response = await client.get("/bot/status")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["auto_trade_enabled"] is False
+    assert payload["manual_confirmation_required"] is True
+    assert payload["margin_mode"] in {"isolated", "cross"}
+    assert payload["leverage"] >= 1
+
+
+@pytest.mark.asyncio
+async def test_bot_settings_persist(client):
+    update_response = await client.post(
+        "/bot/settings",
+        json={
+            "auto_trade_enabled": True,
+            "manual_confirmation_required": False,
+            "margin_mode": "isolated",
+            "leverage": 12,
+        },
+    )
+    assert update_response.status_code == 200, update_response.text
+    data = update_response.json()
+    assert data["auto_trade_enabled"] is True
+    assert data["manual_confirmation_required"] is False
+    assert data["margin_mode"] == "isolated"
+    assert data["leverage"] == 12
+
+    status_response = await client.get("/bot/status")
+    assert status_response.status_code == 200
+    status_data = status_response.json()
+    assert status_data["auto_trade_enabled"] is True
+    assert status_data["manual_confirmation_required"] is False
+    assert status_data["margin_mode"] == "isolated"
+    assert status_data["leverage"] == 12
+
+
+@pytest.mark.asyncio
+async def test_bot_reports_returns_recent_signals(client):
+    payload = {
+        "symbol": "ADAUSDT",
+        "action": "buy",
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "quantity": 15.0,
+    }
+    response = await client.post(
+        "/webhook/tradingview",
+        json=payload,
+        headers={"X-TRADINGVIEW-TOKEN": "test-token"},
+    )
+    assert response.status_code == 201, response.text
+
+    report_response = await client.get("/bot/reports", params={"limit": 1})
+    assert report_response.status_code == 200
+    reports = report_response.json()
+    assert len(reports) == 1
+    assert reports[0]["symbol"] == "ADAUSDT"

--- a/backend/tests/test_bot_handlers.py
+++ b/backend/tests/test_bot_handlers.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from bot.config import BotSettings
+from bot.handlers import BotHandlers
+from bot.middleware import AdminMiddleware
+from bot.models import BotState
+
+
+class DummyBackendClient:
+    def __init__(self) -> None:
+        self.state = BotState()
+        self.updated_payload: dict[str, object] | None = None
+
+    async def get_state(self) -> BotState:
+        return self.state
+
+    async def update_state(self, **kwargs) -> BotState:
+        self.updated_payload = kwargs
+        for key, value in kwargs.items():
+            setattr(self.state, key, value)
+        return self.state
+
+    async def fetch_recent_signals(self, limit: int):
+        return []
+
+
+class DummyMessage:
+    def __init__(self, text: str = "", user_id: int = 1, username: str = "admin") -> None:
+        self.text = text
+        self.from_user = SimpleNamespace(id=user_id, username=username)
+        self.replies: list[dict] = []
+
+    async def answer(self, text: str, **kwargs):
+        self.replies.append({"text": text, "kwargs": kwargs})
+        return SimpleNamespace()
+
+
+class DummyEditableMessage(DummyMessage):
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.edits: list[dict] = []
+
+    async def edit_text(self, text: str, **kwargs):
+        self.edits.append({"text": text, "kwargs": kwargs})
+        return SimpleNamespace()
+
+
+class DummyCallbackQuery:
+    def __init__(self, data: str, user_id: int = 1, username: str = "admin") -> None:
+        self.data = data
+        self.from_user = SimpleNamespace(id=user_id, username=username)
+        self.message = DummyEditableMessage()
+        self.answers: list[dict] = []
+
+    async def answer(self, text: str | None = None, **kwargs):
+        self.answers.append({"text": text, "kwargs": kwargs})
+        return True
+
+
+@pytest.mark.asyncio
+async def test_toggle_autotrade_command_updates_state():
+    settings = BotSettings(
+        telegram_bot_token="token",
+        telegram_admin_ids="1",
+        backend_base_url="http://test",
+    )
+    client = DummyBackendClient()
+    handlers = BotHandlers(client, settings)
+    message = DummyMessage(text="/autotrade")
+
+    await handlers.toggle_autotrade(message)
+
+    assert client.updated_payload == {"auto_trade_enabled": True}
+    assert any("Auto-Trade: ON" in reply["text"] for reply in message.replies)
+
+
+@pytest.mark.asyncio
+async def test_leverage_callback_updates_keyboard():
+    settings = BotSettings(
+        telegram_bot_token="token",
+        telegram_admin_ids="1",
+        backend_base_url="http://test",
+    )
+    client = DummyBackendClient()
+    handlers = BotHandlers(client, settings)
+    callback = DummyCallbackQuery("leverage:10")
+
+    await handlers.leverage_callback(callback)
+
+    assert client.updated_payload == {"leverage": 10}
+    assert any("x10" in edit["text"] for edit in callback.message.edits)
+    assert callback.answers[0]["text"] == "Leverage set to x10"
+
+
+@pytest.mark.asyncio
+async def test_admin_middleware_blocks_unauthorized_user():
+    middleware = AdminMiddleware({1})
+    unauthorized_message = DummyMessage(user_id=99)
+    called = False
+
+    async def handler(event, data):
+        nonlocal called
+        called = True
+
+    await middleware(handler, unauthorized_message, {})
+
+    assert not called
+    assert unauthorized_message.replies
+    assert "not authorized" in unauthorized_message.replies[0]["text"].lower()

--- a/bot/__init__.py
+++ b/bot/__init__.py
@@ -1,0 +1,1 @@
+"""Telegram bot package for TVTelegramBingX."""

--- a/bot/backend_client.py
+++ b/bot/backend_client.py
@@ -1,0 +1,73 @@
+"""HTTP client facade used by the Telegram bot."""
+from __future__ import annotations
+
+from collections.abc import Sequence
+from contextlib import asynccontextmanager
+from typing import AsyncIterator
+
+import httpx
+
+from .models import BotState, SignalRead
+
+
+class BackendClient:
+    """Thin wrapper around the backend HTTP API."""
+
+    def __init__(self, base_url: str, timeout: float = 10.0) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._timeout = timeout
+        self._client: httpx.AsyncClient | None = None
+
+    @asynccontextmanager
+    async def session(self) -> AsyncIterator[httpx.AsyncClient]:
+        if self._client is None:
+            self._client = httpx.AsyncClient(base_url=self._base_url, timeout=self._timeout)
+        try:
+            yield self._client
+        finally:
+            # connection pooling is desired so we keep the client open
+            pass
+
+    async def get_state(self) -> BotState:
+        async with self.session() as client:
+            response = await client.get("/bot/status")
+            response.raise_for_status()
+            return BotState.model_validate(response.json())
+
+    async def update_state(
+        self,
+        *,
+        auto_trade_enabled: bool | None = None,
+        manual_confirmation_required: bool | None = None,
+        margin_mode: str | None = None,
+        leverage: int | None = None,
+    ) -> BotState:
+        payload: dict[str, object] = {}
+        if auto_trade_enabled is not None:
+            payload["auto_trade_enabled"] = auto_trade_enabled
+        if manual_confirmation_required is not None:
+            payload["manual_confirmation_required"] = manual_confirmation_required
+        if margin_mode is not None:
+            payload["margin_mode"] = margin_mode
+        if leverage is not None:
+            payload["leverage"] = leverage
+
+        async with self.session() as client:
+            response = await client.post("/bot/settings", json=payload)
+            response.raise_for_status()
+            return BotState.model_validate(response.json())
+
+    async def fetch_recent_signals(self, limit: int = 5) -> Sequence[SignalRead]:
+        async with self.session() as client:
+            response = await client.get("/signals", params={"limit": limit})
+            response.raise_for_status()
+            items = response.json()
+            return [SignalRead.model_validate(item) for item in items]
+
+    async def aclose(self) -> None:
+        if self._client is not None:
+            await self._client.aclose()
+            self._client = None
+
+
+__all__ = ["BackendClient"]

--- a/bot/config.py
+++ b/bot/config.py
@@ -1,0 +1,47 @@
+"""Configuration helpers for the Telegram bot runtime."""
+from __future__ import annotations
+
+from functools import lru_cache
+
+from pydantic import Field, model_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class BotSettings(BaseSettings):
+    """Environment-driven settings for the Telegram bot."""
+
+    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", extra="ignore")
+
+    telegram_bot_token: str = Field(..., alias="TELEGRAM_BOT_TOKEN")
+    telegram_admin_ids: str | None = Field(default=None, alias="TELEGRAM_ADMIN_IDS")
+    admin_ids: set[int] = Field(default_factory=set)
+    backend_base_url: str = Field("http://localhost:8000", alias="BACKEND_BASE_URL")
+    request_timeout: float = Field(10.0, alias="BOT_BACKEND_TIMEOUT", ge=1.0)
+    report_limit: int = Field(5, alias="BOT_REPORT_LIMIT", ge=1)
+
+    @model_validator(mode="after")
+    def _parse_admins(self) -> "BotSettings":
+        if not self.telegram_admin_ids:
+            self.admin_ids: set[int] = set()
+        else:
+            ids: set[int] = set()
+            for raw in str(self.telegram_admin_ids).replace(";", ",").split(","):
+                raw = raw.strip()
+                if not raw:
+                    continue
+                try:
+                    ids.add(int(raw))
+                except ValueError as exc:  # pragma: no cover - validation edge case
+                    raise ValueError(f"Invalid admin id '{raw}'") from exc
+            self.admin_ids = ids
+        return self
+
+
+@lru_cache
+def get_settings() -> BotSettings:
+    """Return cached bot settings instance."""
+
+    return BotSettings()  # type: ignore[call-arg]
+
+
+__all__ = ["BotSettings", "get_settings"]

--- a/bot/handlers.py
+++ b/bot/handlers.py
@@ -1,0 +1,216 @@
+"""Telegram command and callback handlers."""
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Iterable
+
+from aiogram import F, Router
+from aiogram.filters import Command
+from aiogram.types import CallbackQuery, Message
+
+from .backend_client import BackendClient
+from .config import BotSettings
+from .keyboards import main_menu
+from .models import BotState, SignalRead
+
+logger = logging.getLogger(__name__)
+
+
+class BotHandlers:
+    """Collection of Telegram bot handlers with injected dependencies."""
+
+    def __init__(self, client: BackendClient, settings: BotSettings) -> None:
+        self._client = client
+        self._settings = settings
+
+    async def start(self, message: Message) -> None:
+        await self.help(message)
+
+    async def help(self, message: Message) -> None:
+        text = (
+            "<b>TVTelegramBingX Control Bot</b>\n\n"
+            "Available commands:\n"
+            "/status - Show current automation status\n"
+            "/autotrade - Toggle auto-trading\n"
+            "/confirmations - Toggle manual confirmations\n"
+            "/margin [isolated|cross] - Set margin mode\n"
+            "/leverage [value] - Set leverage multiplier\n"
+            "/reports - Show recent signals\n"
+            "/help - Show this message"
+        )
+        await message.answer(text, disable_web_page_preview=True)
+
+    async def status(self, message: Message) -> None:
+        state = await self._client.get_state()
+        await self._respond(message, state)
+        self._audit(message, "status", state)
+
+    async def toggle_autotrade(self, message: Message) -> None:
+        await self._toggle_auto_trade(message)
+
+    async def toggle_manual_confirmations(self, message: Message) -> None:
+        await self._toggle_manual(message)
+
+    async def margin(self, message: Message) -> None:
+        mode = self._extract_argument(message.text)
+        if mode in {"isolated", "cross"}:
+            new_state = await self._client.update_state(margin_mode=mode)
+            await self._respond(message, new_state, notice=f"Margin mode updated to {mode}")
+            self._audit(message, "margin", new_state)
+            return
+        await self.status(message)
+
+    async def leverage(self, message: Message) -> None:
+        argument = self._extract_argument(message.text)
+        if argument is not None:
+            try:
+                leverage = int(argument)
+            except ValueError:
+                await message.answer("Please provide a numeric leverage value, e.g. /leverage 5")
+                return
+            new_state = await self._client.update_state(leverage=leverage)
+            await self._respond(message, new_state, notice=f"Leverage updated to x{leverage}")
+            self._audit(message, "leverage", new_state)
+            return
+        await self.status(message)
+
+    async def reports(self, message: Message) -> None:
+        signals = await self._client.fetch_recent_signals(self._settings.report_limit)
+        text = self._format_signals(signals)
+        await message.answer(text, disable_web_page_preview=True)
+        self._audit(message, "reports", {"count": len(signals)})
+
+    async def refresh_callback(self, callback: CallbackQuery) -> None:
+        state = await self._client.get_state()
+        await self._respond(callback, state, notice="Status updated")
+        self._audit(callback, "status-refresh", state)
+
+    async def toggle_autotrade_callback(self, callback: CallbackQuery) -> None:
+        await self._toggle_auto_trade(callback)
+
+    async def toggle_manual_callback(self, callback: CallbackQuery) -> None:
+        await self._toggle_manual(callback)
+
+    async def margin_callback(self, callback: CallbackQuery) -> None:
+        mode = (callback.data or "").split(":", 1)[-1]
+        if mode not in {"isolated", "cross"}:
+            await callback.answer("Unknown margin mode")
+            return
+        state = await self._client.update_state(margin_mode=mode)
+        await self._respond(callback, state, notice=f"Margin set to {mode}")
+        self._audit(callback, "margin", state)
+
+    async def leverage_callback(self, callback: CallbackQuery) -> None:
+        value = (callback.data or "").split(":", 1)[-1]
+        try:
+            leverage = int(value)
+        except ValueError:
+            await callback.answer("Invalid leverage value")
+            return
+        state = await self._client.update_state(leverage=leverage)
+        await self._respond(callback, state, notice=f"Leverage set to x{leverage}")
+        self._audit(callback, "leverage", state)
+
+    async def noop_callback(self, callback: CallbackQuery) -> None:
+        await callback.answer()
+
+    def _format_signals(self, signals: Iterable[SignalRead]) -> str:
+        if not signals:
+            return "No recent signals were found."
+        lines = ["<b>Recent Signals</b>"]
+        for signal in signals:
+            timestamp = signal.timestamp.strftime("%Y-%m-%d %H:%M:%S")
+            lines.append(
+                f"• {signal.symbol} — <b>{signal.action.upper()}</b> — qty {signal.quantity} at {timestamp}"
+            )
+        return "\n".join(lines)
+
+    async def _toggle_auto_trade(self, event: Message | CallbackQuery) -> None:
+        state = await self._client.get_state()
+        new_state = await self._client.update_state(auto_trade_enabled=not state.auto_trade_enabled)
+        notice = "Auto-Trade enabled" if new_state.auto_trade_enabled else "Auto-Trade disabled"
+        await self._respond(event, new_state, notice=notice)
+        self._audit(event, "autotrade", new_state)
+
+    async def _toggle_manual(self, event: Message | CallbackQuery) -> None:
+        state = await self._client.get_state()
+        new_state = await self._client.update_state(
+            manual_confirmation_required=not state.manual_confirmation_required
+        )
+        notice = (
+            "Manual confirmations enabled"
+            if new_state.manual_confirmation_required
+            else "Manual confirmations disabled"
+        )
+        await self._respond(event, new_state, notice=notice)
+        self._audit(event, "manual", new_state)
+
+    async def _respond(self, event: Message | CallbackQuery, state: BotState, *, notice: str | None = None) -> None:
+        text = self._format_state(state)
+        markup = main_menu(state)
+        if isinstance(event, CallbackQuery):
+            if notice:
+                await event.answer(notice)
+            else:
+                await event.answer()
+            if event.message:
+                await event.message.edit_text(text, reply_markup=markup, disable_web_page_preview=True)
+        else:
+            body = f"{notice}\n\n{text}" if notice else text
+            await event.answer(body, reply_markup=markup, disable_web_page_preview=True)
+
+    def _format_state(self, state: BotState) -> str:
+        updated = state.updated_at
+        if isinstance(updated, datetime):
+            updated_text = updated.strftime("%Y-%m-%d %H:%M:%S UTC")
+        else:
+            updated_text = "never"
+        return (
+            "<b>Automation Status</b>\n"
+            f"Auto-Trade: {'ON' if state.auto_trade_enabled else 'OFF'}\n"
+            f"Manual Confirmations: {'ON' if state.manual_confirmation_required else 'OFF'}\n"
+            f"Margin Mode: {state.margin_mode}\n"
+            f"Leverage: x{state.leverage}\n"
+            f"Last Updated: {updated_text}"
+        )
+
+    def _audit(self, event: Message | CallbackQuery, action: str, payload: object) -> None:
+        user = getattr(event, "from_user", None)
+        user_id = getattr(user, "id", None)
+        username = getattr(user, "username", None)
+        logger.info(
+            "Bot action executed",
+            extra={"action": action, "user_id": user_id, "username": username, "payload": payload},
+        )
+
+    def _extract_argument(self, text: str | None) -> str | None:
+        if not text:
+            return None
+        parts = text.split()
+        if len(parts) < 2:
+            return None
+        return parts[1].strip()
+
+
+def build_router(handlers: BotHandlers) -> Router:
+    router = Router(name="bot-handlers")
+    router.message.register(handlers.start, Command(commands=["start"]))
+    router.message.register(handlers.help, Command(commands=["help"]))
+    router.message.register(handlers.status, Command(commands=["status"]))
+    router.message.register(handlers.toggle_autotrade, Command(commands=["autotrade"]))
+    router.message.register(handlers.toggle_manual_confirmations, Command(commands=["confirmations"]))
+    router.message.register(handlers.margin, Command(commands=["margin"]))
+    router.message.register(handlers.leverage, Command(commands=["leverage"]))
+    router.message.register(handlers.reports, Command(commands=["reports"]))
+
+    router.callback_query.register(handlers.refresh_callback, F.data == "refresh:status")
+    router.callback_query.register(handlers.toggle_autotrade_callback, F.data == "toggle:auto_trade")
+    router.callback_query.register(handlers.toggle_manual_callback, F.data == "toggle:manual")
+    router.callback_query.register(handlers.margin_callback, F.data.startswith("margin:"))
+    router.callback_query.register(handlers.leverage_callback, F.data.startswith("leverage:"))
+    router.callback_query.register(handlers.noop_callback, F.data.startswith("noop:"))
+    return router
+
+
+__all__ = ["BotHandlers", "build_router"]

--- a/bot/keyboards.py
+++ b/bot/keyboards.py
@@ -1,0 +1,40 @@
+"""Inline keyboard builders for Telegram bot interactions."""
+from __future__ import annotations
+
+from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
+
+from .models import BotState
+
+
+def main_menu(state: BotState) -> InlineKeyboardMarkup:
+    """Return the main inline keyboard for the status view."""
+
+    auto_text = "Auto-Trade: ON" if state.auto_trade_enabled else "Auto-Trade: OFF"
+    confirm_text = (
+        "Manual Confirmations: ON" if state.manual_confirmation_required else "Manual Confirmations: OFF"
+    )
+    margin_text = f"Margin: {state.margin_mode.title()}"
+    leverage_text = f"Leverage: x{state.leverage}"
+
+    return InlineKeyboardMarkup(
+        inline_keyboard=[
+            [InlineKeyboardButton(text=auto_text, callback_data="toggle:auto_trade")],
+            [InlineKeyboardButton(text=confirm_text, callback_data="toggle:manual")],
+            [
+                InlineKeyboardButton(text="Isolated", callback_data="margin:isolated"),
+                InlineKeyboardButton(text="Cross", callback_data="margin:cross"),
+            ],
+            [
+                InlineKeyboardButton(text="x3", callback_data="leverage:3"),
+                InlineKeyboardButton(text="x5", callback_data="leverage:5"),
+                InlineKeyboardButton(text="x10", callback_data="leverage:10"),
+                InlineKeyboardButton(text="x20", callback_data="leverage:20"),
+            ],
+            [InlineKeyboardButton(text=margin_text, callback_data="noop:margin")],
+            [InlineKeyboardButton(text=leverage_text, callback_data="noop:leverage")],
+            [InlineKeyboardButton(text="Refresh", callback_data="refresh:status")],
+        ]
+    )
+
+
+__all__ = ["main_menu"]

--- a/bot/main.py
+++ b/bot/main.py
@@ -1,0 +1,43 @@
+"""Async entrypoint for running the Telegram bot."""
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from aiogram import Bot, Dispatcher
+from aiogram.enums import ParseMode
+
+from .backend_client import BackendClient
+from .config import BotSettings, get_settings
+from .handlers import BotHandlers, build_router
+from .middleware import AdminMiddleware
+
+logger = logging.getLogger(__name__)
+
+
+async def _setup_dispatcher(settings: BotSettings, client: BackendClient) -> Dispatcher:
+    dispatcher = Dispatcher()
+    handlers = BotHandlers(client, settings)
+    router = build_router(handlers)
+    dispatcher.include_router(router)
+    dispatcher.message.middleware(AdminMiddleware(settings.admin_ids))
+    dispatcher.callback_query.middleware(AdminMiddleware(settings.admin_ids))
+    return dispatcher
+
+
+async def main() -> None:
+    settings = get_settings()
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
+    client = BackendClient(settings.backend_base_url, timeout=settings.request_timeout)
+    dispatcher = await _setup_dispatcher(settings, client)
+    bot = Bot(token=settings.telegram_bot_token, parse_mode=ParseMode.HTML)
+    logger.info("Starting Telegram bot", extra={"admins": list(settings.admin_ids)})
+    try:
+        await dispatcher.start_polling(bot, allowed_updates=dispatcher.resolve_used_update_types())
+    finally:
+        await client.aclose()
+        await bot.session.close()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual entrypoint
+    asyncio.run(main())

--- a/bot/middleware.py
+++ b/bot/middleware.py
@@ -1,0 +1,39 @@
+"""Custom middleware for authorization and dependency wiring."""
+from __future__ import annotations
+
+import logging
+from typing import Any, Awaitable, Callable, Dict
+
+from aiogram import BaseMiddleware
+from aiogram.types import CallbackQuery, Message
+
+logger = logging.getLogger(__name__)
+
+
+class AdminMiddleware(BaseMiddleware):
+    """Restrict bot usage to whitelisted Telegram user IDs."""
+
+    def __init__(self, admin_ids: set[int]) -> None:
+        super().__init__()
+        self._admin_ids = admin_ids
+
+    async def __call__(
+        self,
+        handler: Callable[[Message, Dict[str, Any]], Awaitable[Any]],
+        event: Message | CallbackQuery,
+        data: Dict[str, Any],
+    ) -> Any:
+        from_user = getattr(event, "from_user", None)
+        user_id = getattr(from_user, "id", None)
+        if user_id is None or user_id not in self._admin_ids:
+            username = getattr(from_user, "username", "unknown")
+            logger.warning("Blocked unauthorized bot access", extra={"user_id": user_id, "username": username})
+            if isinstance(event, Message):
+                await event.answer("You are not authorized to use this bot.")
+            elif isinstance(event, CallbackQuery):
+                await event.answer("Unauthorized", show_alert=True)
+            return None
+        return await handler(event, data)
+
+
+__all__ = ["AdminMiddleware"]

--- a/bot/models.py
+++ b/bot/models.py
@@ -1,0 +1,36 @@
+"""Pydantic models shared inside the bot package."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal, Sequence
+
+from pydantic import BaseModel, Field
+
+
+class BotState(BaseModel):
+    """Mirror of the backend bot state representation."""
+
+    auto_trade_enabled: bool = False
+    manual_confirmation_required: bool = True
+    margin_mode: Literal["isolated", "cross"] = "isolated"
+    leverage: int = Field(1, ge=1)
+    updated_at: datetime | None = None
+
+
+class SignalRead(BaseModel):
+    """Subset of signal information used in bot reports."""
+
+    id: int
+    symbol: str
+    action: str
+    timestamp: datetime
+    quantity: float
+
+
+class SignalsReport(BaseModel):
+    """Aggregated report payload for templating convenience."""
+
+    items: Sequence[SignalRead]
+
+
+__all__ = ["BotState", "SignalRead", "SignalsReport"]

--- a/docs/telegram_bot_deployment.md
+++ b/docs/telegram_bot_deployment.md
@@ -1,0 +1,98 @@
+# Telegram Bot Deployment (Non-Docker)
+
+This guide describes how to run the Telegram control bot alongside the FastAPI backend without relying on Docker.
+
+## Prerequisites
+
+* Python 3.11 or newer available on the host.
+* An API endpoint for the backend (usually `http://127.0.0.1:8000`).
+* A Telegram bot token created via [@BotFather](https://core.telegram.org/bots#botfather).
+* The Telegram user IDs that are allowed to interact with the bot (comma separated).
+
+## Environment configuration
+
+Create a `.env` file in the repository root or export the variables in your shell:
+
+```bash
+TELEGRAM_BOT_TOKEN="123456789:ABC..."
+TELEGRAM_ADMIN_IDS="12345678,87654321"
+BACKEND_BASE_URL="http://127.0.0.1:8000"
+BOT_REPORT_LIMIT=5
+BOT_BACKEND_TIMEOUT=15
+```
+
+The bot shares the `.env` file with the backend. If you keep the backend configuration there already, simply append the variables above.
+
+## Running locally
+
+Install dependencies inside the `backend` project first:
+
+```bash
+cd backend
+pip install -e .[dev]
+```
+
+Then start the bot:
+
+```bash
+python -m bot.main
+```
+
+The bot uses long polling by default. Logs are emitted to stdout and include basic auditing information (user ID, username, action).
+
+## systemd service example
+
+Create a unit file at `/etc/systemd/system/tvtelegram-bot.service`:
+
+```ini
+[Unit]
+Description=TVTelegramBingX Telegram Bot
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/tvtelegrambingx
+EnvironmentFile=/opt/tvtelegrambingx/.env
+ExecStart=/usr/bin/python3 -m bot.main
+Restart=on-failure
+User=tvtelegram
+Group=tvtelegram
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Reload and enable the service:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now tvtelegram-bot.service
+```
+
+Check logs with `journalctl -fu tvtelegram-bot.service`.
+
+## PM2 process manager (Node.js environments)
+
+If you already use [PM2](https://pm2.keymetrics.io/) to supervise processes:
+
+```bash
+pm2 start "python3 -m bot.main" --name tvtelegram-bot --cwd /opt/tvtelegrambingx \
+  --interpreter python3 --env .env
+pm2 save
+```
+
+PM2 will restart the bot on failure and on machine reboot when combined with `pm2 startup`.
+
+## Updating
+
+When new versions are deployed:
+
+1. Pull the latest code and reinstall dependencies if `pyproject.toml` changed.
+2. Reload the backend service if required.
+3. Restart the bot process (`systemctl restart tvtelegram-bot` or `pm2 restart tvtelegram-bot`).
+
+## Troubleshooting
+
+* **401 Unauthorized from backend** – Ensure the backend is reachable and the `BACKEND_BASE_URL` variable matches its address.
+* **Bot ignores commands** – Confirm that the Telegram user ID is listed in `TELEGRAM_ADMIN_IDS`. IDs must be numeric.
+* **No reports** – The `/bot/reports` endpoint only returns stored signals. Check that the webhook is ingesting signals correctly.


### PR DESCRIPTION
## Summary
- add a bot package powered by aiogram with handlers, keyboards, and backend client for trading controls
- expose bot control service and HTTP endpoints in the FastAPI backend with persistence for automation preferences
- document non-Docker bot deployment options and cover the new logic with API and handler unit tests

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68e22412d3ac832da3b518fe74083fb4