### PR TITLE
Ensure run.sh enforces Python 3.11 for the backend venv

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -6,25 +6,20 @@ cd "${ROOT_DIR}"
 
 ensure_python_version() {
   local candidate="$1"
+  local python_path=""
 
-  if ! command -v "${candidate}" >/dev/null 2>&1; then
+  if [[ -x "${candidate}" ]]; then
+    python_path="${candidate}"
+  else
+    python_path="$(command -v "${candidate}" 2>/dev/null || true)"
+  fi
+
+  if [[ -z "${python_path}" ]]; then
     return 1
   fi
 
-  "${candidate}" -c 'import sys; exit(0 if sys.version_info >= (3, 11) else 1)' >/dev/null 2>&1
+  "${python_path}" -c 'import sys; exit(0 if sys.version_info >= (3, 11) else 1)' >/dev/null 2>&1
 }
-
-if ensure_python_version python3; then
-  PYTHON_BIN="python3"
-elif ensure_python_version python3.11; then
-  PYTHON_BIN="python3.11"
-else
-  cat <<'MSG'
-[run.sh] Konnte keinen Python-Interpreter >= 3.11 finden.
-Bitte installiere Python 3.11 (oder neuer) und stelle sicher, dass python3 oder python3.11 im PATH verfügbar ist.
-MSG
-  exit 1
-fi
 
 if [[ ! -f .env ]]; then
   cat <<'MSG'
@@ -39,16 +34,42 @@ MSG
 fi
 
 VENV_DIR="${ROOT_DIR}/backend/.venv"
+VENV_PYTHON="${VENV_DIR}/bin/python"
+
+if [[ -d "${VENV_DIR}" ]] && ! ensure_python_version "${VENV_PYTHON}"; then
+  echo "[run.sh] Entferne virtuelles Environment mit inkompatibler Python-Version (< 3.11)"
+  rm -rf "${VENV_DIR}"
+fi
 
 if [[ ! -d "${VENV_DIR}" ]]; then
+  if ensure_python_version python3; then
+    PYTHON_BIN="python3"
+  elif ensure_python_version python3.11; then
+    PYTHON_BIN="python3.11"
+  else
+    cat <<'MSG'
+[run.sh] Konnte keinen Python-Interpreter >= 3.11 finden.
+Bitte installiere Python 3.11 (oder neuer) und stelle sicher, dass python3 oder python3.11 im PATH verfügbar ist.
+MSG
+    exit 1
+  fi
+
   echo "[run.sh] Erstelle virtuelles Python-Environment unter backend/.venv"
   "${PYTHON_BIN}" -m venv "${VENV_DIR}"
 fi
 
+if ! ensure_python_version "${VENV_PYTHON}"; then
+  cat <<'MSG'
+[run.sh] Das virtuelle Environment verwendet eine inkompatible Python-Version (< 3.11).
+Bitte stelle sicher, dass ein Python-Interpreter >= 3.11 verfügbar ist und führe das Skript erneut aus.
+MSG
+  exit 1
+fi
+
+PYTHON_BIN="${VENV_PYTHON}"
+
 export VIRTUAL_ENV="${VENV_DIR}"
 export PATH="${VENV_DIR}/bin:${PATH}"
-
-PYTHON_BIN="${VENV_DIR}/bin/python"
 
 # Stelle sicher, dass pip aktuell ist und Abhängigkeiten installiert werden.
 (


### PR DESCRIPTION
## Summary
- allow ensure_python_version to validate both PATH lookups and direct executables
- validate backend/.venv against the Python >=3.11 requirement and recreate it when outdated
- reuse the same requirement when selecting a system interpreter and fail fast when none is available

## Testing
- PATH='${TMPBIN}:/bin:/usr/bin' bash run.sh (fails cleanly without Python ≥3.11)
- PYTHONPATH=/tmp/pip_stub PIP_NO_INDEX=1 bash run.sh

------
https://chatgpt.com/codex/tasks/task_e_68e23be6f5d0832d961512e51d8b20d1