### PR TITLE
Fix run script backend launch directory

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -80,7 +80,6 @@ export PATH="${VENV_DIR}/bin:${PATH}"
 )
 
 PORT="${PORT:-8000}"
-cd "${ROOT_DIR}/backend"
 
 echo "[run.sh] Starte Backend unter http://0.0.0.0:${PORT}"
 exec "${VENV_DIR}/bin/uvicorn" backend.app.main:app --host 0.0.0.0 --port "${PORT}" --reload


### PR DESCRIPTION
## Summary
- prevent run.sh from changing into backend before launching uvicorn so the module path resolves from the repository root

## Testing
- ./run.sh *(fails: pip cannot reach proxy to install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68e2419fa1cc832daa9bbfac4b5f9d2b