### PR TITLE
Remove non-Python footer from telemetry module

### DIFF
--- a/backend/app/telemetry.py
+++ b/backend/app/telemetry.py
@@ -114,4 +114,3 @@ def configure_backend_telemetry(app: FastAPI, *, settings: Settings | None = Non
 
     _INITIALISED = True
 
-*** End of File


### PR DESCRIPTION
## Summary
- remove the stray `*** End of File` footer so telemetry.py is valid Python

## Testing
- ./run.sh *(fails: requires .env to be created)*

------
https://chatgpt.com/codex/tasks/task_e_68e243994954832d91b1bbfc4163fdb6