### PR TITLE
Add aiosqlite dependency to backend

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "opentelemetry-instrumentation-httpx>=0.48b0",
     "opentelemetry-instrumentation-asyncpg>=0.48b0",
     "prometheus-client>=0.20",
+    "aiosqlite>=0.19",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- add aiosqlite to the backend's core dependency list so the SQLite driver is installed with the service

## Testing
- pip install -e ".[dev]" *(fails: Cannot connect to proxy to download setuptools)*
- ./run.sh *(fails: missing .env file as noted in script output)*

------
https://chatgpt.com/codex/tasks/task_e_68e244e214e0832d8ddbf54471372352