### PR TITLE
Notify admins about bot startup state

### DIFF
--- a/aiogram/__init__.py
+++ b/aiogram/__init__.py
@@ -1,8 +1,46 @@
 """Minimal aiogram stub for tests."""
 from __future__ import annotations
 
-from dataclasses import dataclass
 from typing import Any, Callable
+
+
+class _DummySession:
+    async def close(self) -> None:  # pragma: no cover - noop for tests
+        return None
+
+
+class Bot:
+    """Minimal Bot stub implementing only the bits used in tests."""
+
+    def __init__(self, token: str, parse_mode: str | None = None) -> None:
+        self.token = token
+        self.parse_mode = parse_mode
+        self.session = _DummySession()
+
+    async def send_message(self, chat_id: int, text: str) -> None:  # pragma: no cover - noop
+        return None
+
+
+class _MiddlewareRegistry:
+    def middleware(self, *args: Any, **kwargs: Any) -> None:  # pragma: no cover - noop
+        return None
+
+
+class Dispatcher:
+    """Minimal dispatcher stub used by tests."""
+
+    def __init__(self) -> None:
+        self.message = _MiddlewareRegistry()
+        self.callback_query = _MiddlewareRegistry()
+
+    def include_router(self, router: Any) -> None:  # pragma: no cover - noop
+        return None
+
+    def resolve_used_update_types(self) -> list[str]:  # pragma: no cover - noop
+        return []
+
+    async def start_polling(self, *args: Any, **kwargs: Any) -> None:  # pragma: no cover - noop
+        return None
 
 
 class F:  # pragma: no cover - placeholder
@@ -26,4 +64,4 @@ class BaseMiddleware:
         pass
 
 
-__all__ = ["F", "Router", "BaseMiddleware"]
+__all__ = ["F", "Router", "BaseMiddleware", "Bot", "Dispatcher"]

--- a/aiogram/enums.py
+++ b/aiogram/enums.py
@@ -1,0 +1,11 @@
+"""Minimal enum definitions used by the tests."""
+from __future__ import annotations
+
+from enum import Enum
+
+
+class ParseMode(str, Enum):
+    HTML = "HTML"
+
+
+__all__ = ["ParseMode"]

--- a/bot/config.py
+++ b/bot/config.py
@@ -32,6 +32,7 @@ class BotSettings(BaseSettings):
     metrics_enabled: bool = Field(True, alias="BOT_METRICS_ENABLED")
     metrics_host: str = Field("0.0.0.0", alias="BOT_METRICS_HOST")
     metrics_port: int = Field(9000, alias="BOT_METRICS_PORT", ge=1, le=65535)
+    broadcast_chat_id: int | None = Field(default=None, alias="BOT_BROADCAST_CHAT_ID")
 
     @model_validator(mode="after")
     def _parse_admins(self) -> "BotSettings":

--- a/bot/main.py
+++ b/bot/main.py
@@ -6,13 +6,21 @@ import logging
 
 from aiogram import Bot, Dispatcher
 from aiogram.enums import ParseMode
+try:  # pragma: no cover - fallback for tests without aiogram installed
+    from aiogram.exceptions import TelegramAPIError, TelegramForbiddenError
+except Exception:  # pragma: no cover - fallback definitions
+    class TelegramAPIError(Exception):
+        """Fallback base error when aiogram exceptions are unavailable."""
+
+    class TelegramForbiddenError(TelegramAPIError):
+        """Fallback forbidden error when aiogram exceptions are unavailable."""
 
 from .backend_client import BackendClient
 from .config import BotSettings, get_settings
 from .handlers import BotHandlers, build_router
 from .middleware import AdminMiddleware
 from .metrics import start_metrics_server
-from .telemetry import configure_bot_telemetry
+from .models import BotState
 
 logger = logging.getLogger(__name__)
 
@@ -27,8 +35,53 @@ async def _setup_dispatcher(settings: BotSettings, client: BackendClient) -> Dis
     return dispatcher
 
 
+def _format_startup_message(state: BotState) -> str:
+    """Return a human readable status summary for startup notifications."""
+
+    auto_trade_status = "aktiviert" if state.auto_trade_enabled else "deaktiviert"
+    confirmation_status = (
+        "erforderlich" if state.manual_confirmation_required else "optional"
+    )
+    return (
+        "🤖 Bot gestartet\n"
+        f"• Automatischer Handel: {auto_trade_status}\n"
+        f"• Bestätigung: {confirmation_status}\n"
+        f"• Margin-Modus: {state.margin_mode}\n"
+        f"• Hebel: {state.leverage}x"
+    )
+
+
+async def _announce_startup(bot: Bot, client: BackendClient, settings: BotSettings) -> None:
+    """Fetch the current state and broadcast it to configured recipients."""
+
+    try:
+        state = await client.get_state()
+    except Exception:  # pragma: no cover - defensive guard
+        logger.exception("Unable to fetch bot state during startup")
+        message = "🤖 Bot gestartet, Status konnte nicht geladen werden."
+    else:
+        message = _format_startup_message(state)
+
+    recipients = set(settings.admin_ids)
+    if settings.broadcast_chat_id is not None:
+        recipients.add(settings.broadcast_chat_id)
+
+    for chat_id in recipients:
+        try:
+            await bot.send_message(chat_id, message)
+        except TelegramForbiddenError:
+            logger.warning(
+                "Startup notification forbidden for chat", extra={"chat_id": chat_id}
+            )
+        except TelegramAPIError:
+            logger.exception(
+                "Failed to deliver startup notification", extra={"chat_id": chat_id}
+            )
+
+
 async def main() -> None:
     settings = get_settings()
+    from .telemetry import configure_bot_telemetry  # Local import to avoid test dependency
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
     configure_bot_telemetry(settings)
     if settings.metrics_enabled:
@@ -44,6 +97,7 @@ async def main() -> None:
     dispatcher = await _setup_dispatcher(settings, client)
     bot = Bot(token=settings.telegram_bot_token, parse_mode=ParseMode.HTML)
     logger.info("Starting Telegram bot", extra={"admins": list(settings.admin_ids)})
+    await _announce_startup(bot, client, settings)
     try:
         await dispatcher.start_polling(bot, allowed_updates=dispatcher.resolve_used_update_types())
     finally:

--- a/bot/tests/__init__.py
+++ b/bot/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test suite for the Telegram bot package."""

--- a/bot/tests/test_startup_notifications.py
+++ b/bot/tests/test_startup_notifications.py
@@ -1,0 +1,61 @@
+"""Tests for startup notification broadcasting."""
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from ..main import _announce_startup, TelegramForbiddenError
+from ..models import BotState
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_startup_notification_sent_to_all_recipients(caplog: pytest.LogCaptureFixture) -> None:
+    bot = AsyncMock()
+    client = AsyncMock()
+    client.get_state.return_value = BotState(
+        auto_trade_enabled=True,
+        manual_confirmation_required=False,
+        margin_mode="cross",
+        leverage=10,
+    )
+    settings = SimpleNamespace(admin_ids={1, 2}, broadcast_chat_id=3)
+
+    caplog.set_level(logging.INFO)
+
+    await _announce_startup(bot, client, settings)
+
+    assert client.get_state.await_count == 1
+    assert bot.send_message.await_count == 3
+    sent_to = {call.args[0] for call in bot.send_message.await_args_list}
+    assert sent_to == {1, 2, 3}
+
+
+@pytest.mark.anyio
+async def test_startup_notification_logs_forbidden_error(caplog: pytest.LogCaptureFixture) -> None:
+    bot = AsyncMock()
+    client = AsyncMock()
+    client.get_state.return_value = BotState()
+
+    async def _send_message(chat_id: int, _: str) -> None:
+        if chat_id == 2:
+            raise TelegramForbiddenError("Forbidden")
+
+    bot.send_message.side_effect = _send_message
+
+    settings = SimpleNamespace(admin_ids={1, 2}, broadcast_chat_id=None)
+
+    with caplog.at_level(logging.WARNING):
+        await _announce_startup(bot, client, settings)
+
+    assert bot.send_message.await_count == 2
+    warnings = [record for record in caplog.records if record.levelno == logging.WARNING]
+    assert warnings, "Expected a warning log entry"
+    assert warnings[0].message.startswith("Startup notification forbidden")


### PR DESCRIPTION
## Summary
- fetch the backend bot state on startup and send a status summary to admins or the optional broadcast chat while tolerating Telegram API failures
- add configuration for a broadcast chat id and extend the local aiogram stub to cover the minimal interfaces needed for testing
- cover the startup announcement flow with asynchronous tests ensuring successes and logged failures

## Testing
- `pytest bot/tests/test_startup_notifications.py`


------
https://chatgpt.com/codex/tasks/task_e_68e263003e48832d8b7766764e93ec59