### PR TITLE
Add Telegram bot skeleton and configuration handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,48 @@
 # TVTelegramBingX
+
+## Prerequisites
+
+- Python 3.10+
+- [python-telegram-bot](https://docs.python-telegram-bot.org/en/stable/) library
+
+Install dependencies:
+
+```bash
+pip install python-telegram-bot
+```
+
+## Configuration
+
+The bot reads configuration values from environment variables or an optional `.env` file located in the project root. The following variables are supported:
+
+- `TELEGRAM_BOT_TOKEN`: Telegram Bot API token.
+
+You can export the variable directly:
+
+```bash
+export TELEGRAM_BOT_TOKEN="your-telegram-bot-token"
+```
+
+Or create a `.env` file:
+
+```env
+TELEGRAM_BOT_TOKEN=your-telegram-bot-token
+```
+
+## Running the bot
+
+Run the Telegram bot locally:
+
+```bash
+python -m bot.telegram_bot
+```
+
+When the bot starts it logs its initialization status and exposes the following commands:
+
+- `/status` – Confirms that the bot is online.
+- `/help` – Lists available commands.
+- `/report` – Placeholder for future trade reports.
+- `/margin` – Placeholder for margin information.
+- `/leverage` – Placeholder for leverage settings.
+
+Financial data responses currently return placeholder messages until the BingX integration is implemented.

--- a/bot/__init__.py
+++ b/bot/__init__.py
@@ -1,0 +1,3 @@
+"""Telegram bot package for TVTelegramBingX."""
+
+__all__ = ["telegram_bot"]

--- a/bot/telegram_bot.py
+++ b/bot/telegram_bot.py
@@ -1,0 +1,128 @@
+"""Telegram bot entry point for TVTelegramBingX."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Final
+
+from telegram import Update
+from telegram.ext import Application, ApplicationBuilder, CommandHandler, ContextTypes
+
+from config import Settings, get_settings
+
+LOGGER: Final = logging.getLogger(__name__)
+
+
+async def status(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Reply with a simple status message."""
+
+    if not update.message:
+        return
+
+    await update.message.reply_text("✅ Bot is running. BingX integration coming soon.")
+
+
+async def help_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Provide helpful information to the user."""
+
+    if not update.message:
+        return
+
+    await update.message.reply_text(
+        "Available commands:\n"
+        "/status - Check whether the bot is online.\n"
+        "/report - Placeholder for trade reports.\n"
+        "/margin - Placeholder for margin information.\n"
+        "/leverage - Placeholder for leverage settings."
+    )
+
+
+async def report(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Return placeholder report information."""
+
+    if not update.message:
+        return
+
+    await update.message.reply_text(
+        "📊 Reports are not available yet. BingX integration is under development."
+    )
+
+
+async def margin(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Return placeholder margin information."""
+
+    if not update.message:
+        return
+
+    await update.message.reply_text(
+        "💰 Margin data is currently unavailable. Check back after BingX integration."
+    )
+
+
+async def leverage(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Return placeholder leverage information."""
+
+    if not update.message:
+        return
+
+    await update.message.reply_text(
+        "📈 Leverage details will be displayed once BingX integration is ready."
+    )
+
+
+def _build_application(settings: Settings) -> Application:
+    """Create and configure the Telegram application."""
+
+    application = ApplicationBuilder().token(settings.telegram_bot_token).build()
+
+    application.add_handler(CommandHandler("status", status))
+    application.add_handler(CommandHandler("help", help_command))
+    application.add_handler(CommandHandler("report", report))
+    application.add_handler(CommandHandler("margin", margin))
+    application.add_handler(CommandHandler("leverage", leverage))
+
+    return application
+
+
+async def run_bot(settings: Settings | None = None) -> None:
+    """Run the Telegram bot until it is stopped."""
+
+    settings = settings or get_settings()
+    LOGGER.info("Starting Telegram bot polling loop")
+
+    application = _build_application(settings)
+
+    LOGGER.info("Bot connected. Listening for commands...")
+    await application.initialize()
+    await application.start()
+
+    try:
+        await application.updater.start_polling()
+        await application.updater.idle()
+    finally:
+        await application.updater.stop()
+        await application.stop()
+        await application.shutdown()
+        LOGGER.info("Telegram bot stopped")
+
+
+def main() -> None:
+    """Entry point for running the Telegram bot via CLI."""
+
+    logging.basicConfig(
+        format="%(asctime)s | %(levelname)s | %(name)s | %(message)s",
+        level=logging.INFO,
+    )
+
+    try:
+        settings = get_settings()
+    except RuntimeError as error:
+        LOGGER.error("Configuration error: %s", error)
+        raise
+
+    asyncio.run(run_bot(settings=settings))
+
+
+if __name__ == "__main__":
+    main()

--- a/config.py
+++ b/config.py
@@ -1,0 +1,75 @@
+"""Application configuration utilities."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+
+def load_dotenv(dotenv_path: Optional[str] = None) -> None:
+    """Load environment variables from a ``.env`` file if present.
+
+    Parameters
+    ----------
+    dotenv_path:
+        Optional path to a custom ``.env`` file. Defaults to ``.env`` in the
+        project root when not provided.
+    """
+
+    path = Path(dotenv_path or ".env")
+    if not path.exists():
+        return
+
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+
+        if "=" not in line:
+            continue
+
+        key, value = line.split("=", 1)
+        key = key.strip()
+        value = value.strip().strip('"')
+        os.environ.setdefault(key, value)
+
+
+@dataclass(frozen=True)
+class Settings:
+    """Container for application-wide configuration values."""
+
+    telegram_bot_token: str
+
+
+def get_settings(dotenv_path: Optional[str] = None) -> Settings:
+    """Return the application settings.
+
+    Loading order:
+    1. Existing environment variables.
+    2. Variables declared in ``.env`` (without overriding existing values).
+
+    Parameters
+    ----------
+    dotenv_path:
+        Optional path to a custom ``.env`` file.
+
+    Raises
+    ------
+    RuntimeError
+        If required configuration values are missing.
+    """
+
+    load_dotenv(dotenv_path=dotenv_path)
+
+    token = os.getenv("TELEGRAM_BOT_TOKEN")
+    if not token:
+        raise RuntimeError(
+            "TELEGRAM_BOT_TOKEN is not configured. Set the environment variable or add it to the .env file."
+        )
+
+    return Settings(telegram_bot_token=token)
+
+
+__all__ = ["Settings", "get_settings", "load_dotenv"]


### PR DESCRIPTION
## Summary
- add a configuration module that reads the Telegram bot token from environment variables or an optional .env file
- create a telegram bot package with placeholder command handlers and startup logging
- document dependency installation, configuration, and run instructions in the README

## Testing
- not run (requires Telegram credentials)


------
https://chatgpt.com/codex/tasks/task_e_68e26aefba84832d83f08bcd46b32898