### PR TITLE
Integrate BingX REST client into Telegram bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,12 @@
 
 - Python 3.10+
 - [python-telegram-bot](https://docs.python-telegram-bot.org/en/stable/) library
+- [httpx](https://www.python-httpx.org/) for the BingX REST client
 
 Install dependencies:
 
 ```bash
-pip install python-telegram-bot
+pip install python-telegram-bot httpx
 ```
 
 ## Configuration
@@ -16,6 +17,9 @@ pip install python-telegram-bot
 The bot reads configuration values from environment variables or an optional `.env` file located in the project root. The following variables are supported:
 
 - `TELEGRAM_BOT_TOKEN`: Telegram Bot API token.
+- `BINGX_API_KEY`: API key for your BingX account (optional, enables financial commands).
+- `BINGX_API_SECRET`: API secret for your BingX account (optional, enables financial commands).
+- `BINGX_BASE_URL`: (Optional) Override the BingX REST base URL. Defaults to `https://open-api.bingx.com`.
 
 You can export the variable directly:
 
@@ -27,6 +31,8 @@ Or create a `.env` file:
 
 ```env
 TELEGRAM_BOT_TOKEN=your-telegram-bot-token
+BINGX_API_KEY=your-bingx-api-key
+BINGX_API_SECRET=your-bingx-api-secret
 ```
 
 ## Running the bot
@@ -41,8 +47,8 @@ When the bot starts it logs its initialization status and exposes the following 
 
 - `/status` – Confirms that the bot is online.
 - `/help` – Lists available commands.
-- `/report` – Placeholder for future trade reports.
-- `/margin` – Placeholder for margin information.
-- `/leverage` – Placeholder for leverage settings.
+- `/report` – Shows an overview of your BingX balance and open positions.
+- `/margin` – Retrieves the latest margin breakdown from BingX.
+- `/leverage` – Displays leverage details for currently open positions.
 
-Financial data responses currently return placeholder messages until the BingX integration is implemented.
+Financial commands require valid BingX API credentials. If credentials are missing, the bot replies with a helpful reminder.

--- a/config.py
+++ b/config.py
@@ -41,6 +41,9 @@ class Settings:
     """Container for application-wide configuration values."""
 
     telegram_bot_token: str
+    bingx_api_key: Optional[str] = None
+    bingx_api_secret: Optional[str] = None
+    bingx_base_url: str = "https://open-api.bingx.com"
 
 
 def get_settings(dotenv_path: Optional[str] = None) -> Settings:
@@ -69,7 +72,16 @@ def get_settings(dotenv_path: Optional[str] = None) -> Settings:
             "TELEGRAM_BOT_TOKEN is not configured. Set the environment variable or add it to the .env file."
         )
 
-    return Settings(telegram_bot_token=token)
+    api_key = os.getenv("BINGX_API_KEY")
+    api_secret = os.getenv("BINGX_API_SECRET")
+    base_url = os.getenv("BINGX_BASE_URL", "https://open-api.bingx.com")
+
+    return Settings(
+        telegram_bot_token=token,
+        bingx_api_key=api_key,
+        bingx_api_secret=api_secret,
+        bingx_base_url=base_url,
+    )
 
 
 __all__ = ["Settings", "get_settings", "load_dotenv"]

--- a/integrations/__init__.py
+++ b/integrations/__init__.py
@@ -1,0 +1,5 @@
+"""Integration packages for external services."""
+
+from .bingx_client import BingXClient, BingXClientError
+
+__all__ = ["BingXClient", "BingXClientError"]

--- a/integrations/bingx_client.py
+++ b/integrations/bingx_client.py
@@ -1,0 +1,128 @@
+"""Async client for interacting with the BingX REST API."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import time
+from dataclasses import dataclass, field
+from typing import Any, Mapping, MutableMapping
+
+import httpx
+
+
+class BingXClientError(RuntimeError):
+    """Base exception raised when the BingX API returns an error."""
+
+
+@dataclass
+class BingXClient:
+    """Thin asynchronous wrapper around the subset of the BingX REST API."""
+
+    api_key: str
+    api_secret: str
+    base_url: str = "https://open-api.bingx.com"
+    timeout: float = 10.0
+    _client: httpx.AsyncClient | None = field(default=None, init=False, repr=False)
+
+    async def __aenter__(self) -> "BingXClient":
+        self._client = httpx.AsyncClient(base_url=self.base_url, timeout=self.timeout)
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:  # type: ignore[override]
+        if self._client:
+            await self._client.aclose()
+            self._client = None
+
+    # ------------------------------------------------------------------
+    # Public REST helpers
+    # ------------------------------------------------------------------
+    async def get_account_balance(self, currency: str | None = None) -> Any:
+        """Return the account balance for the given currency (default USDT)."""
+
+        params: dict[str, Any] = {}
+        if currency:
+            params["currency"] = currency
+        data = await self._request("GET", "/openApi/swap/v2/user/balance", params=params)
+        return data
+
+    async def get_margin_summary(self, symbol: str | None = None) -> Any:
+        """Return the margin overview for either the entire account or a symbol."""
+
+        params: dict[str, Any] = {}
+        if symbol:
+            params["symbol"] = symbol
+        data = await self._request("GET", "/openApi/swap/v2/user/margin", params=params)
+        return data
+
+    async def get_open_positions(self, symbol: str | None = None) -> Any:
+        """Return the currently open positions."""
+
+        params: dict[str, Any] = {}
+        if symbol:
+            params["symbol"] = symbol
+        data = await self._request("GET", "/openApi/swap/v2/user/positions", params=params)
+        return data
+
+    async def get_leverage_settings(self, symbol: str | None = None) -> Any:
+        """Return configured leverage values for the given symbol or entire account."""
+
+        params: dict[str, Any] = {}
+        if symbol:
+            params["symbol"] = symbol
+        data = await self._request("GET", "/openApi/swap/v2/user/leverage", params=params)
+        return data
+
+    # ------------------------------------------------------------------
+    # Internal request helpers
+    # ------------------------------------------------------------------
+    async def _request(
+        self, method: str, path: str, *, params: Mapping[str, Any] | None = None
+    ) -> Any:
+        if not self._client:
+            raise BingXClientError(
+                "HTTP client not initialised. Use 'async with BingXClient(...)' when calling the API."
+            )
+
+        signed_params = self._sign_parameters(params)
+        headers = {"X-BX-APIKEY": self.api_key}
+
+        response = await self._client.request(method, path, params=signed_params, headers=headers)
+
+        try:
+            payload = response.json()
+        except ValueError as exc:  # pragma: no cover - defensive programming
+            raise BingXClientError("Failed to decode BingX response as JSON") from exc
+
+        if response.status_code != 200:
+            raise BingXClientError(
+                f"BingX API returned HTTP {response.status_code}: {payload!r}"
+            )
+
+        if isinstance(payload, Mapping):
+            code = payload.get("code")
+            if code not in (0, "0", None):
+                message = payload.get("msg") or payload.get("message") or "Unknown error"
+                raise BingXClientError(f"BingX API error {code}: {message}")
+            return payload.get("data", payload)
+
+        return payload
+
+    def _sign_parameters(self, params: Mapping[str, Any] | None) -> MutableMapping[str, Any]:
+        """Return parameters with the BingX HMAC SHA256 signature attached."""
+
+        payload: MutableMapping[str, Any] = dict(params or {})
+        timestamp = payload.get("timestamp") or str(int(time.time() * 1000))
+        payload["timestamp"] = timestamp
+
+        canonical_query = "&".join(f"{key}={payload[key]}" for key in sorted(payload))
+        signature = hmac.new(
+            self.api_secret.encode("utf-8"),
+            canonical_query.encode("utf-8"),
+            hashlib.sha256,
+        ).hexdigest()
+        payload["signature"] = signature
+        return payload
+
+
+__all__ = ["BingXClient", "BingXClientError"]


### PR DESCRIPTION
## Summary
- add an async BingX REST client wrapper that signs requests and exposes balance, margin, leverage, and position helpers
- expand configuration and Telegram handlers to use the client for /report, /margin, and /leverage replies when credentials are configured
- document the new environment variables and dependency required for the BingX integration

## Testing
- python -m compileall bot/telegram_bot.py integrations/bingx_client.py

------
https://chatgpt.com/codex/tasks/task_e_68e26b96118c832db95524ae022d3b28