### PR TITLE
Add run script for Telegram bot startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ BINGX_API_SECRET=your-bingx-api-secret
 Run the Telegram bot locally:
 
 ```bash
+./run.sh
+```
+
+You can also invoke the module directly if you prefer:
+
+```bash
 python -m bot.telegram_bot
 ```
 

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '\n=== Starting TVTelegramBingX bot ===\n'
+
+if [ -f .env ]; then
+  set -a
+  # shellcheck disable=SC1091
+  source .env
+  set +a
+fi
+
+python -m bot.telegram_bot


### PR DESCRIPTION
## Summary
- add a run.sh helper script that loads .env variables and executes the Telegram bot module
- document the new helper script in the README alongside the direct python invocation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e26e30ecc0832d900facb45c65c3e1