### PR TITLE
Add example environment template and update README

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# ------------------------------
+# Telegram configuration
+# ------------------------------
+TELEGRAM_BOT_TOKEN=your-telegram-bot-token
+TELEGRAM_CHAT_ID=your-telegram-chat-id
+
+# ------------------------------
+# BingX API credentials
+# ------------------------------
+BINGX_API_KEY=your-bingx-api-key
+BINGX_API_SECRET=your-bingx-api-secret

--- a/README.md
+++ b/README.md
@@ -36,6 +36,13 @@ BINGX_API_SECRET=your-bingx-api-secret
 #BINGX_BASE_URL=https://open-api.bingx.com
 ```
 
+You can also duplicate the provided `.env.example` file and adjust the values before running `./run.sh`:
+
+```bash
+cp .env.example .env
+$EDITOR .env
+```
+
 ## Running the bot
 
 Run the Telegram bot locally:


### PR DESCRIPTION
## Summary
- add a `.env.example` template with sample Telegram and BingX values to simplify configuration
- document how to copy the example environment file in the README configuration instructions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e27070c288832da9697e6f4e30b9af