### PR TITLE
Fix Telegram bot shutdown for new API

### DIFF
--- a/bot/telegram_bot.py
+++ b/bot/telegram_bot.py
@@ -317,11 +317,11 @@ async def run_bot(settings: Settings | None = None) -> None:
 
     LOGGER.info("Bot connected. Listening for commands...")
     await application.initialize()
-    await application.start()
 
     try:
+        await application.start()
         await application.updater.start_polling()
-        await application.updater.idle()
+        await application.updater.wait()
     finally:
         await application.updater.stop()
         await application.stop()


### PR DESCRIPTION
## Summary
- replace the deprecated updater idle call with the supported wait primitive
- move application.start into the guarded block so the shutdown sequence matches the current polling API

## Testing
- ./run.sh (fails: ModuleNotFoundError: No module named 'telegram')

------
https://chatgpt.com/codex/tasks/task_e_68e2723ad35c832dbb1f5d10ba6bd70b