### PR TITLE
Add TradingView webhook service and TLS configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,13 @@ TELEGRAM_CHAT_ID=your-telegram-chat-id
 # ------------------------------
 BINGX_API_KEY=your-bingx-api-key
 BINGX_API_SECRET=your-bingx-api-secret
+
+# ------------------------------
+# TradingView webhook (optional)
+# ------------------------------
+TRADINGVIEW_WEBHOOK_ENABLED=false
+TRADINGVIEW_WEBHOOK_SECRET=choose-a-strong-secret
+TLS_CERT_PATH=/path/to/certificate.pem
+TLS_KEY_PATH=/path/to/private-key.pem
+#TRADINGVIEW_WEBHOOK_HOST=0.0.0.0
+#TRADINGVIEW_WEBHOOK_PORT=8443

--- a/bot/telegram_bot.py
+++ b/bot/telegram_bot.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
+import json
 import logging
 import re
+from collections import deque
 from collections.abc import Mapping, Sequence
 from typing import Any, Final
 
@@ -13,6 +16,7 @@ from telegram.ext import Application, ApplicationBuilder, CommandHandler, Contex
 
 from config import Settings, get_settings
 from integrations.bingx_client import BingXClient, BingXClientError
+from webhook.dispatcher import get_alert_queue
 
 LOGGER: Final = logging.getLogger(__name__)
 
@@ -96,6 +100,36 @@ def _format_margin_payload(payload: Any) -> str:
         return "\n".join(lines)
 
     return "💰 Margin data: " + str(payload)
+
+
+def _format_tradingview_alert(alert: Mapping[str, Any]) -> str:
+    """Return a readable representation of a TradingView alert."""
+
+    lines = ["📢 TradingView alert received!"]
+
+    message = None
+    for key in ("message", "alert", "text", "body"):
+        value = alert.get(key) if isinstance(alert, Mapping) else None
+        if value:
+            message = str(value)
+            break
+
+    if message:
+        lines.append(message)
+
+    ticker = alert.get("ticker") if isinstance(alert, Mapping) else None
+    price = alert.get("price") if isinstance(alert, Mapping) else None
+    if ticker:
+        extra = f"Ticker: {ticker}"
+        if price is not None:
+            extra += f" | Price: {_format_number(price)}"
+        lines.append(extra)
+
+    if len(lines) == 1:
+        formatted = json.dumps(alert, indent=2, sort_keys=True, default=str)
+        lines.append(formatted)
+
+    return "\n".join(lines)
 
 
 def _format_positions_payload(payload: Any) -> str:
@@ -292,6 +326,35 @@ async def leverage(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     await update.message.reply_text("\n".join(message_lines))
 
 
+async def _consume_tradingview_alerts(application: Application, settings: Settings) -> None:
+    """Continuously consume TradingView alerts and forward them to Telegram."""
+
+    queue = get_alert_queue()
+    history = application.bot_data.setdefault("tradingview_alerts", deque(maxlen=20))
+    assert isinstance(history, deque)
+
+    while True:
+        alert = await queue.get()
+        try:
+            if not isinstance(alert, Mapping):
+                LOGGER.info("Received TradingView alert without mapping payload: %s", alert)
+                continue
+
+            history.append(alert)
+            LOGGER.info("Stored TradingView alert for bot handlers")
+
+            if settings.telegram_chat_id:
+                try:
+                    await application.bot.send_message(
+                        chat_id=settings.telegram_chat_id,
+                        text=_format_tradingview_alert(alert),
+                    )
+                except Exception:  # pragma: no cover - network/Telegram errors
+                    LOGGER.exception("Failed to send TradingView alert to Telegram chat %s", settings.telegram_chat_id)
+        finally:
+            queue.task_done()
+
+
 def _build_application(settings: Settings) -> Application:
     """Create and configure the Telegram application."""
 
@@ -317,8 +380,14 @@ async def run_bot(settings: Settings | None = None) -> None:
 
     async with application:
         stop_event = asyncio.Event()
+        consumer_task: asyncio.Task[None] | None = None
         try:
             await application.start()
+            if settings.tradingview_webhook_enabled:
+                consumer_task = application.create_task(
+                    _consume_tradingview_alerts(application, settings)
+                )
+
             await application.updater.start_polling()
 
             LOGGER.info("Bot connected. Listening for commands...")
@@ -327,6 +396,10 @@ async def run_bot(settings: Settings | None = None) -> None:
         except (asyncio.CancelledError, KeyboardInterrupt):
             LOGGER.info("Shutdown requested. Stopping Telegram bot...")
         finally:
+            if consumer_task is not None:
+                consumer_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await consumer_task
             await application.stop()
 
     LOGGER.info("Telegram bot stopped")

--- a/run.sh
+++ b/run.sh
@@ -10,4 +10,43 @@ if [ -f .env ]; then
   set +a
 fi
 
+cleanup() {
+  if [ -n "${WEBHOOK_PID:-}" ]; then
+    printf '\nStopping webhook server (PID %s)\n' "$WEBHOOK_PID"
+    kill "$WEBHOOK_PID" >/dev/null 2>&1 || true
+    wait "$WEBHOOK_PID" 2>/dev/null || true
+  fi
+}
+
+trap cleanup EXIT INT TERM
+
+is_enabled() {
+  case "${1,,}" in
+    1|true|yes|on) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+if is_enabled "${TRADINGVIEW_WEBHOOK_ENABLED:-}"; then
+  : "${TRADINGVIEW_WEBHOOK_SECRET:?TRADINGVIEW_WEBHOOK_SECRET must be set when the webhook is enabled}" 
+  : "${TLS_CERT_PATH:?TLS_CERT_PATH must be set when the webhook is enabled}" 
+  : "${TLS_KEY_PATH:?TLS_KEY_PATH must be set when the webhook is enabled}" 
+
+  WEBHOOK_HOST=${TRADINGVIEW_WEBHOOK_HOST:-0.0.0.0}
+  WEBHOOK_PORT=${TRADINGVIEW_WEBHOOK_PORT:-8443}
+
+  printf '\n=== Starting TradingView webhook (https://%s:%s/tradingview-webhook) ===\n' "$WEBHOOK_HOST" "$WEBHOOK_PORT"
+  uvicorn --factory webhook.server:create_app \
+    --host "$WEBHOOK_HOST" \
+    --port "$WEBHOOK_PORT" \
+    --ssl-certfile "$TLS_CERT_PATH" \
+    --ssl-keyfile "$TLS_KEY_PATH" &
+  WEBHOOK_PID=$!
+  sleep 1
+fi
+
 python -m bot.telegram_bot
+
+if [ -n "${WEBHOOK_PID:-}" ]; then
+  wait "$WEBHOOK_PID" 2>/dev/null || true
+fi

--- a/webhook/__init__.py
+++ b/webhook/__init__.py
@@ -1,0 +1,5 @@
+"""Webhook integration package for TradingView alerts."""
+
+from .server import create_app
+
+__all__ = ["create_app"]

--- a/webhook/dispatcher.py
+++ b/webhook/dispatcher.py
@@ -1,0 +1,25 @@
+"""Utilities for dispatching webhook alerts to the Telegram bot."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Mapping
+
+AlertPayload = Mapping[str, Any]
+
+_ALERT_QUEUE: asyncio.Queue[AlertPayload] = asyncio.Queue()
+
+
+def get_alert_queue() -> asyncio.Queue[AlertPayload]:
+    """Return the shared asyncio queue for TradingView alerts."""
+
+    return _ALERT_QUEUE
+
+
+async def publish_alert(alert: AlertPayload) -> None:
+    """Add a validated alert to the shared queue."""
+
+    await _ALERT_QUEUE.put(alert)
+
+
+__all__ = ["AlertPayload", "get_alert_queue", "publish_alert"]

--- a/webhook/server.py
+++ b/webhook/server.py
@@ -1,0 +1,85 @@
+"""FastAPI application exposing a TradingView webhook endpoint."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from fastapi import FastAPI, HTTPException, Request, status
+
+from config import Settings, get_settings
+from webhook.dispatcher import publish_alert
+
+LOGGER = logging.getLogger(__name__)
+
+_SECRET_HEADER_CANDIDATES = (
+    "X-Tradingview-Secret",
+    "X-TRADINGVIEW-SECRET",
+    "X-Webhook-Secret",
+)
+
+
+def _extract_secret(request: Request, payload: Any) -> str | None:
+    """Return the shared secret from headers or payload."""
+
+    for header_name in _SECRET_HEADER_CANDIDATES:
+        value = request.headers.get(header_name)
+        if value:
+            return value
+
+    if isinstance(payload, dict):
+        secret_candidate = payload.get("secret") or payload.get("password")
+        if isinstance(secret_candidate, str):
+            return secret_candidate
+
+    return None
+
+
+def create_app(settings: Settings | None = None) -> FastAPI:
+    """Create a FastAPI application wired to the alert dispatcher."""
+
+    settings = settings or get_settings()
+    if not settings.tradingview_webhook_enabled:
+        raise RuntimeError(
+            "TradingView webhook is disabled. Set TRADINGVIEW_WEBHOOK_ENABLED=true to enable it."
+        )
+
+    secret = settings.tradingview_webhook_secret
+    if not secret:
+        raise RuntimeError("TradingView webhook secret is not configured.")
+
+    app = FastAPI(title="TVTelegramBingX TradingView Webhook")
+
+    @app.post("/tradingview-webhook")
+    async def tradingview_webhook(request: Request) -> dict[str, str]:
+        try:
+            payload = await request.json()
+        except Exception as exc:  # pragma: no cover - FastAPI wraps request errors
+            LOGGER.debug("Failed to decode webhook payload", exc_info=exc)
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Invalid JSON payload received.",
+            ) from exc
+
+        provided_secret = _extract_secret(request, payload)
+        if provided_secret != secret:
+            LOGGER.warning("Rejected webhook call due to invalid secret")
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Invalid webhook secret.",
+            )
+
+        if not isinstance(payload, dict):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Webhook payload must be a JSON object.",
+            )
+
+        await publish_alert(payload)
+        LOGGER.info("TradingView alert queued for Telegram processing")
+        return {"status": "accepted"}
+
+    return app
+
+
+__all__ = ["create_app"]


### PR DESCRIPTION
## Summary
- add a FastAPI TradingView webhook server that validates a shared secret and publishes alerts to the Telegram dispatcher queue
- extend configuration and bot logic to support webhook settings, TLS files, and automatic alert forwarding to a configured chat
- update run script, environment example, and README with webhook workflow and setup instructions

## Testing
- python -m compileall bot webhook config.py

------
https://chatgpt.com/codex/tasks/task_e_68e277960334832dac839927952a6581