### PR TITLE
Add unified launcher for Telegram bot and webhook

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -10,43 +10,4 @@ if [ -f .env ]; then
   set +a
 fi
 
-cleanup() {
-  if [ -n "${WEBHOOK_PID:-}" ]; then
-    printf '\nStopping webhook server (PID %s)\n' "$WEBHOOK_PID"
-    kill "$WEBHOOK_PID" >/dev/null 2>&1 || true
-    wait "$WEBHOOK_PID" 2>/dev/null || true
-  fi
-}
-
-trap cleanup EXIT INT TERM
-
-is_enabled() {
-  case "${1,,}" in
-    1|true|yes|on) return 0 ;;
-    *) return 1 ;;
-  esac
-}
-
-if is_enabled "${TRADINGVIEW_WEBHOOK_ENABLED:-}"; then
-  : "${TRADINGVIEW_WEBHOOK_SECRET:?TRADINGVIEW_WEBHOOK_SECRET must be set when the webhook is enabled}" 
-  : "${TLS_CERT_PATH:?TLS_CERT_PATH must be set when the webhook is enabled}" 
-  : "${TLS_KEY_PATH:?TLS_KEY_PATH must be set when the webhook is enabled}" 
-
-  WEBHOOK_HOST=${TRADINGVIEW_WEBHOOK_HOST:-0.0.0.0}
-  WEBHOOK_PORT=${TRADINGVIEW_WEBHOOK_PORT:-8443}
-
-  printf '\n=== Starting TradingView webhook (https://%s:%s/tradingview-webhook) ===\n' "$WEBHOOK_HOST" "$WEBHOOK_PORT"
-  uvicorn --factory webhook.server:create_app \
-    --host "$WEBHOOK_HOST" \
-    --port "$WEBHOOK_PORT" \
-    --ssl-certfile "$TLS_CERT_PATH" \
-    --ssl-keyfile "$TLS_KEY_PATH" &
-  WEBHOOK_PID=$!
-  sleep 1
-fi
-
-python -m bot.telegram_bot
-
-if [ -n "${WEBHOOK_PID:-}" ]; then
-  wait "$WEBHOOK_PID" 2>/dev/null || true
-fi
+python -m tvtelegrambingx.main

--- a/tvtelegrambingx/__init__.py
+++ b/tvtelegrambingx/__init__.py
@@ -1,0 +1,5 @@
+"""TVTelegramBingX package."""
+
+__all__ = ["__version__"]
+
+__version__ = "0.1.0"

--- a/tvtelegrambingx/main.py
+++ b/tvtelegrambingx/main.py
@@ -1,0 +1,146 @@
+"""Unified application entry point for the Telegram bot and webhook server."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import os
+import signal
+
+import uvicorn
+
+from bot.telegram_bot import run_bot
+from config import Settings, get_settings
+from webhook.server import create_app
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _resolve_webhook_binding() -> tuple[str, int]:
+    """Return the host/port configuration for the webhook server."""
+
+    host = os.getenv("TRADINGVIEW_WEBHOOK_HOST", "0.0.0.0")
+    port_raw = os.getenv("TRADINGVIEW_WEBHOOK_PORT", "8443")
+    try:
+        port = int(port_raw)
+    except ValueError as exc:  # pragma: no cover - misconfiguration guard
+        raise RuntimeError(
+            "Invalid TRADINGVIEW_WEBHOOK_PORT value. Provide a valid integer."
+        ) from exc
+    return host, port
+
+
+async def _run_webhook_server(settings: Settings) -> None:
+    """Start the TradingView webhook server using uvicorn on the current loop."""
+
+    host, port = _resolve_webhook_binding()
+    if not settings.tls_cert_path or not settings.tls_key_path:
+        raise RuntimeError(
+            "TLS certificate and key must be configured when the webhook is enabled."
+        )
+
+    app = create_app(settings=settings)
+    config = uvicorn.Config(
+        app,
+        host=host,
+        port=port,
+        ssl_certfile=str(settings.tls_cert_path),
+        ssl_keyfile=str(settings.tls_key_path),
+        loop="asyncio",
+        log_level="info",
+    )
+    server = uvicorn.Server(config)
+    server.install_signal_handlers = False
+
+    LOGGER.info(
+        "Starting TradingView webhook server at https://%s:%s/tradingview-webhook",
+        host,
+        port,
+    )
+
+    try:
+        await server.serve()
+    except asyncio.CancelledError:
+        LOGGER.info("Stopping TradingView webhook server")
+        server.should_exit = True
+        with contextlib.suppress(Exception):
+            maybe_shutdown = server.shutdown()
+            if asyncio.iscoroutine(maybe_shutdown):
+                await maybe_shutdown
+        raise
+
+
+async def _run_application(settings: Settings) -> None:
+    """Run the Telegram bot and optional webhook server until shutdown."""
+
+    loop = asyncio.get_running_loop()
+    shutdown_event = asyncio.Event()
+
+    def _request_shutdown() -> None:
+        if not shutdown_event.is_set():
+            LOGGER.info("Shutdown signal received. Stopping services...")
+            shutdown_event.set()
+
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        with contextlib.suppress(NotImplementedError):
+            loop.add_signal_handler(sig, _request_shutdown)
+
+    tasks: list[asyncio.Task[None]] = []
+
+    bot_task = loop.create_task(run_bot(settings), name="telegram-bot")
+    tasks.append(bot_task)
+
+    if settings.tradingview_webhook_enabled:
+        webhook_task = loop.create_task(
+            _run_webhook_server(settings), name="tradingview-webhook"
+        )
+        tasks.append(webhook_task)
+    else:
+        LOGGER.info("TradingView webhook disabled. Only starting Telegram bot.")
+
+    def _propagate_exit(task: asyncio.Task[None]) -> None:
+        if task.cancelled():
+            return
+        exc = task.exception()
+        if exc is not None:
+            LOGGER.exception("Service task failed", exc_info=exc)
+        if not shutdown_event.is_set():
+            shutdown_event.set()
+
+    for task in tasks:
+        task.add_done_callback(_propagate_exit)
+
+    await shutdown_event.wait()
+
+    for task in tasks:
+        task.cancel()
+
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+    for result in results:
+        if isinstance(result, BaseException) and not isinstance(result, asyncio.CancelledError):
+            raise result
+
+
+def main() -> None:
+    """CLI entry point that loads settings and starts all services."""
+
+    logging.basicConfig(
+        format="%(asctime)s | %(levelname)s | %(name)s | %(message)s",
+        level=logging.INFO,
+    )
+
+    try:
+        settings = get_settings()
+    except RuntimeError as error:
+        LOGGER.error("Configuration error: %s", error)
+        raise
+
+    try:
+        asyncio.run(_run_application(settings))
+    except KeyboardInterrupt:  # pragma: no cover - manual interruption
+        LOGGER.info("Interrupted by user. Exiting...")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a tvtelegrambingx Python package with a combined entry point that runs the Telegram bot and uvicorn server on the same asyncio loop
- update run.sh to invoke the unified launcher so the webhook and bot reuse the shared in-memory dispatcher

## Testing
- python -m py_compile tvtelegrambingx/main.py bot/telegram_bot.py webhook/server.py

------
https://chatgpt.com/codex/tasks/task_e_68e281236f40832daa3556e771da6580