### PR TITLE
Handle configurable docs URL in webhook landing page

### DIFF
--- a/tests/test_webhook_server.py
+++ b/tests/test_webhook_server.py
@@ -1,0 +1,55 @@
+"""Tests for the webhook FastAPI application."""
+
+from typing import Any
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from config import Settings
+from webhook.server import create_app
+
+
+def make_settings(**overrides: Any) -> Settings:
+    """Return Settings pre-populated with webhook configuration for tests."""
+
+    base: dict[str, Any] = {
+        "telegram_bot_token": "token",
+        "bingx_api_key": "key",
+        "bingx_api_secret": "secret",
+        "tradingview_webhook_enabled": True,
+        "tradingview_webhook_secret": "webhook-secret",
+    }
+    base.update(overrides)
+    return Settings(**base)
+
+
+def get_root_response(app: FastAPI) -> str:
+    client = TestClient(app)
+    response = client.get("/")
+    assert response.status_code == 200
+    return response.text
+
+
+def test_read_root_uses_app_docs_url() -> None:
+    """The landing page should link to the configured docs URL when available."""
+
+    app = create_app(make_settings())
+    app.docs_url = "/custom-docs"
+
+    page = get_root_response(app)
+
+    assert "href=\"/custom-docs\"" in page
+    assert "Documentation disabled" not in page
+
+
+def test_read_root_handles_docs_disabled() -> None:
+    """When documentation is disabled the page should avoid broken links."""
+
+    app = create_app(make_settings())
+    app.docs_url = None
+
+    page = get_root_response(app)
+
+    assert "Documentation disabled" in page
+    assert "href=\"" not in page
+

--- a/webhook/server.py
+++ b/webhook/server.py
@@ -53,7 +53,12 @@ def create_app(settings: Settings | None = None) -> FastAPI:
 
     @app.get("/", response_class=HTMLResponse)
     async def read_root() -> str:
-        doc_url = "/docs"
+        doc_url = app.docs_url
+        doc_row = (
+            f'      <dt>Documentation</dt><dd><a href="{doc_url}">Interactive API docs</a></dd>\n'
+            if doc_url
+            else "      <dt>Documentation</dt><dd>Documentation disabled</dd>\n"
+        )
         return (
             "<!DOCTYPE html>\n"
             "<html lang=\"en\">\n"
@@ -68,7 +73,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             "    <dl>\n"
             f"      <dt>Service</dt><dd>{app.title}</dd>\n"
             f"      <dt>Version</dt><dd>{app.version}</dd>\n"
-            f"      <dt>Documentation</dt><dd><a href=\"{doc_url}\">Interactive API docs</a></dd>\n"
+            f"{doc_row}"
             "    </dl>\n"
             "  </body>\n"
             "</html>\n"


### PR DESCRIPTION
## Summary
- update the webhook landing page to read `app.docs_url` instead of a hard-coded path
- render a clear documentation-disabled message when the docs URL is missing
- add tests that cover both documentation-enabled and documentation-disabled scenarios

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68e2914494d0832db08feaa30b4b5a82