### PR TITLE
Use Application.run_polling for Telegram bot lifecycle

### DIFF
--- a/bot/telegram_bot.py
+++ b/bot/telegram_bot.py
@@ -379,20 +379,16 @@ async def run_bot(settings: Settings | None = None) -> None:
     application = _build_application(settings)
 
     async with application:
-        stop_event = asyncio.Event()
         consumer_task: asyncio.Task[None] | None = None
         try:
-            await application.start()
             if settings.tradingview_webhook_enabled:
                 consumer_task = application.create_task(
                     _consume_tradingview_alerts(application, settings)
                 )
 
-            await application.updater.start_polling()
-
             LOGGER.info("Bot connected. Listening for commands...")
 
-            await stop_event.wait()
+            await application.run_polling()
         except (asyncio.CancelledError, KeyboardInterrupt):
             LOGGER.info("Shutdown requested. Stopping Telegram bot...")
         finally:
@@ -400,7 +396,6 @@ async def run_bot(settings: Settings | None = None) -> None:
                 consumer_task.cancel()
                 with contextlib.suppress(asyncio.CancelledError):
                     await consumer_task
-            await application.stop()
 
     LOGGER.info("Telegram bot stopped")
 


### PR DESCRIPTION
## Summary
- replace the manual Application start/stop logic with Application.run_polling so we no longer touch the deprecated updater attribute
- drop the unused shutdown event guard while keeping TradingView alert consumption cancellation logic intact

## Testing
- ./run.sh *(fails: ModuleNotFoundError: No module named 'uvicorn')*

------
https://chatgpt.com/codex/tasks/task_e_68e35ef125e4832da9e80dc74c89bae9