### PR TITLE
Load margin snapshot when placing autotrade orders

### DIFF
--- a/bot/state.py
+++ b/bot/state.py
@@ -7,6 +7,8 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any, Mapping
 
+STATE_EXPORT_FILE = Path("state.json")
+
 
 @dataclass
 class BotState:
@@ -127,4 +129,46 @@ def save_state(path: Path, state: BotState) -> None:
     path.write_text(json.dumps(state.to_dict(), indent=2, sort_keys=True), encoding="utf-8")
 
 
-__all__ = ["BotState", "DEFAULT_STATE", "load_state", "save_state"]
+def export_state_snapshot(state: BotState, *, path: Path = STATE_EXPORT_FILE) -> None:
+    """Write a condensed snapshot used by external services to *path*."""
+
+    snapshot = {
+        "autotrade_enabled": state.autotrade_enabled,
+        "margin_mode": state.normalised_margin_mode(),
+        "margin_coin": state.normalised_margin_asset(),
+        "margin_asset": state.normalised_margin_asset(),
+        "leverage": state.leverage,
+        "max_trade_size": state.max_trade_size,
+        "daily_report_time": state.daily_report_time,
+        "last_symbol": state.last_symbol.upper() if state.last_symbol else None,
+    }
+
+    path.write_text(json.dumps(snapshot, indent=2, sort_keys=True), encoding="utf-8")
+
+
+def load_state_snapshot(path: Path = STATE_EXPORT_FILE) -> dict[str, Any] | None:
+    """Return the exported snapshot from *path* if available."""
+
+    if not path.exists():
+        return None
+
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+
+    if isinstance(payload, Mapping):
+        return dict(payload)
+
+    return None
+
+
+__all__ = [
+    "BotState",
+    "DEFAULT_STATE",
+    "STATE_EXPORT_FILE",
+    "export_state_snapshot",
+    "load_state_snapshot",
+    "load_state",
+    "save_state",
+]

--- a/bot/telegram_bot.py
+++ b/bot/telegram_bot.py
@@ -21,11 +21,19 @@ from config import Settings, get_settings
 from integrations.bingx_client import BingXClient, BingXClientError
 from webhook.dispatcher import get_alert_queue
 
-from .state import BotState, load_state, save_state
+from .state import (
+    BotState,
+    export_state_snapshot,
+    load_state,
+    load_state_snapshot,
+    save_state,
+    STATE_EXPORT_FILE,
+)
 
 LOGGER: Final = logging.getLogger(__name__)
 
 STATE_FILE: Final = Path("bot_state.json")
+STATE_SNAPSHOT_FILE: Final = STATE_EXPORT_FILE
 MAIN_KEYBOARD: Final = ReplyKeyboardMarkup(
     [
         ["/start", "/stop", "/status"],
@@ -59,6 +67,11 @@ def _persist_state(context: ContextTypes.DEFAULT_TYPE) -> None:
             save_state(Path(state_file), state)
         except Exception:  # pragma: no cover - filesystem issues are logged only
             LOGGER.exception("Failed to persist bot state to %s", state_file)
+        else:
+            try:
+                export_state_snapshot(state)
+            except Exception:  # pragma: no cover - filesystem issues are logged only
+                LOGGER.exception("Failed to persist state snapshot to %s", STATE_SNAPSHOT_FILE)
 
 
 def _reschedule_daily_report(context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -83,6 +96,14 @@ def _parse_time(value: str) -> time | None:
     return parsed.time()
 
 
+class CommandUsageError(ValueError):
+    """Exception raised when a Telegram command receives invalid arguments."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+        self.message = message
+
+
 def _normalise_symbol(value: str) -> str:
     """Return an uppercase trading symbol without broker prefixes."""
 
@@ -90,6 +111,93 @@ def _normalise_symbol(value: str) -> str:
     if ":" in text:
         text = text.rsplit(":", 1)[-1]
     return text
+
+
+def _looks_like_symbol(value: str) -> bool:
+    """Heuristically decide whether *value* represents a trading symbol."""
+
+    candidate = value.strip().upper()
+    if not candidate:
+        return False
+    if ":" in candidate or "-" in candidate:
+        return True
+    if any(char.isdigit() for char in candidate):
+        return True
+    return len(candidate) > 4
+
+
+def _parse_margin_command_args(args: Sequence[str]) -> tuple[str | None, bool, str, str | None]:
+    """Return ``(symbol, symbol_provided, margin_mode, margin_coin)`` for /set_margin."""
+
+    tokens = [str(arg).strip() for arg in args if str(arg).strip()]
+    if not tokens:
+        raise CommandUsageError(
+            "Bitte gib cross oder isolated an. Beispiel: /set_margin BTCUSDT cross oder /set_margin cross"
+        )
+
+    allowed_modes = {"cross", "crossed", "isolated", "isol"}
+    symbol: str | None = None
+    symbol_was_provided = False
+
+    working = list(tokens)
+
+    if working and working[0].lower() not in allowed_modes:
+        symbol = _normalise_symbol(working.pop(0))
+        symbol_was_provided = True
+
+    mode_index = next((i for i, token in enumerate(working) if token.lower() in allowed_modes), None)
+    if mode_index is None:
+        raise CommandUsageError("Unbekannter Margin-Modus. Erlaubt: cross oder isolated")
+
+    mode_token = working.pop(mode_index).lower()
+    margin_coin = working[0].upper() if working else None
+    margin_mode = "isolated" if mode_token.startswith("isol") else "cross"
+
+    return symbol, symbol_was_provided, margin_mode, margin_coin
+
+
+def _parse_leverage_command_args(args: Sequence[str]) -> tuple[str | None, bool, float, str | None]:
+    """Return ``(symbol, symbol_provided, leverage, margin_coin)`` for /set_leverage."""
+
+    tokens = [str(arg).strip() for arg in args if str(arg).strip()]
+    if not tokens:
+        raise CommandUsageError(
+            "Bitte gib einen numerischen Leverage-Wert an, z.B. /set_leverage 5 oder /set_leverage BTCUSDT 5"
+        )
+
+    def _parse_leverage(token: str) -> float | None:
+        cleaned = token.lower().rstrip("x")
+        try:
+            return float(cleaned)
+        except ValueError:
+            return None
+
+    working = list(tokens)
+    leverage_index = next((i for i, token in enumerate(working) if _parse_leverage(token) is not None), None)
+    if leverage_index is None:
+        raise CommandUsageError(
+            "Bitte gib einen numerischen Leverage-Wert an, z.B. /set_leverage BTCUSDT 5"
+        )
+
+    leverage_value = _parse_leverage(working.pop(leverage_index))
+    assert leverage_value is not None
+
+    if leverage_value <= 0:
+        raise CommandUsageError("Leverage muss größer als 0 sein.")
+
+    symbol: str | None = None
+    symbol_was_provided = False
+
+    for index, token in enumerate(working):
+        if _looks_like_symbol(token):
+            symbol = _normalise_symbol(token)
+            symbol_was_provided = True
+            working.pop(index)
+            break
+
+    margin_coin = working[0].upper() if working else None
+
+    return symbol, symbol_was_provided, leverage_value, margin_coin
 
 
 def _extract_symbol_from_alert(alert: Mapping[str, Any]) -> str | None:
@@ -138,6 +246,11 @@ def _store_last_symbol(application: Application, symbol: str) -> None:
         save_state(state_file, state)
     except Exception:  # pragma: no cover - filesystem issues are logged only
         LOGGER.exception("Failed to persist updated symbol to %s", state_file)
+    else:
+        try:
+            export_state_snapshot(state)
+        except Exception:  # pragma: no cover - filesystem issues are logged only
+            LOGGER.exception("Failed to persist state snapshot to %s", STATE_SNAPSHOT_FILE)
 
 
 def _resolve_symbol_argument(
@@ -880,50 +993,16 @@ async def set_leverage(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     if not update.message:
         return
 
-    args = [str(arg).strip() for arg in (context.args or []) if str(arg).strip()]
-    if not args:
-        await update.message.reply_text(
-            "Bitte gib einen numerischen Leverage-Wert an, z.B. /set_leverage 5 oder /set_leverage BTCUSDT 5",
+    try:
+        symbol, symbol_was_provided, leverage_value, margin_coin = _parse_leverage_command_args(
+            context.args or []
         )
+    except CommandUsageError as exc:
+        await update.message.reply_text(exc.message)
         return
-
-    def _parse_leverage(token: str) -> float | None:
-        cleaned = token.lower().rstrip("x")
-        try:
-            return float(cleaned)
-        except ValueError:
-            return None
-
-    symbol: str | None = None
-    symbol_was_provided = False
-    margin_coin: str | None = None
-
-    value_candidate = _parse_leverage(args[0])
-    remaining = args[1:]
-    if value_candidate is None:
-        symbol = _normalise_symbol(args[0])
-        symbol_was_provided = True
-        if len(args) < 2:
-            await update.message.reply_text(
-                "Bitte gib einen numerischen Leverage-Wert an, z.B. /set_leverage BTCUSDT 5",
-            )
-            return
-        value_candidate = _parse_leverage(args[1])
-        remaining = args[2:]
-
-    if value_candidate is None:
-        await update.message.reply_text("Ungültiger Wert. Beispiel: /set_leverage 10")
-        return
-
-    if value_candidate <= 0:
-        await update.message.reply_text("Leverage muss größer als 0 sein.")
-        return
-
-    if remaining:
-        margin_coin = remaining[0].upper()
 
     state = _state_from_context(context)
-    state.leverage = value_candidate
+    state.leverage = leverage_value
     if margin_coin:
         state.margin_asset = margin_coin
     if symbol and symbol_was_provided:
@@ -931,7 +1010,7 @@ async def set_leverage(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
 
     _persist_state(context)
 
-    responses = [f"Leverage auf {value_candidate:g}x gesetzt."]
+    responses = [f"Leverage auf {leverage_value:g}x gesetzt."]
     if margin_coin:
         responses.append(f"Margin-Coin auf {state.normalised_margin_asset()} gesetzt.")
 
@@ -948,7 +1027,7 @@ async def set_leverage(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
             ) as client:
                 await client.set_leverage(
                     symbol=symbol_for_api,
-                    leverage=value_candidate,
+                    leverage=leverage_value,
                     margin_mode=state.normalised_margin_mode(),
                     margin_coin=state.normalised_margin_asset(),
                 )
@@ -970,42 +1049,16 @@ async def set_margin(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None
     if not update.message:
         return
 
-    args = [str(arg).strip() for arg in (context.args or []) if str(arg).strip()]
-    if not args:
-        await update.message.reply_text(
-            "Bitte gib cross oder isolated an. Beispiel: /set_margin BTCUSDT cross oder /set_margin cross",
+    try:
+        symbol, symbol_was_provided, margin_mode, margin_coin = _parse_margin_command_args(
+            context.args or []
         )
+    except CommandUsageError as exc:
+        await update.message.reply_text(exc.message)
         return
-
-    allowed_modes = {"cross", "crossed", "isolated", "isol"}
-    symbol: str | None = None
-    symbol_was_provided = False
-    margin_coin: str | None = None
-
-    first = args[0].lower()
-    remaining = args[1:]
-    if first in allowed_modes:
-        mode_token = first
-    else:
-        symbol = _normalise_symbol(args[0])
-        symbol_was_provided = True
-        if len(args) < 2:
-            await update.message.reply_text(
-                "Bitte gib cross oder isolated an. Beispiel: /set_margin BTCUSDT cross",
-            )
-            return
-        mode_token = args[1].lower()
-        remaining = args[2:]
-
-    if mode_token not in allowed_modes:
-        await update.message.reply_text("Unbekannter Margin-Modus. Erlaubt: cross oder isolated")
-        return
-
-    if remaining:
-        margin_coin = remaining[0].upper()
 
     state = _state_from_context(context)
-    state.margin_mode = "isolated" if mode_token.startswith("isol") else "cross"
+    state.margin_mode = margin_mode
     if margin_coin:
         state.margin_asset = margin_coin
     if symbol and symbol_was_provided:
@@ -1122,6 +1175,10 @@ async def sync(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     state_file = Path(context.application.bot_data.get("state_file", STATE_FILE))
     state = load_state(state_file)
     context.application.bot_data["state"] = state
+    try:
+        export_state_snapshot(state)
+    except Exception:  # pragma: no cover - filesystem issues are logged only
+        LOGGER.exception("Failed to persist state snapshot to %s", STATE_SNAPSHOT_FILE)
     _reschedule_daily_report(context)
     await update.message.reply_text("Einstellungen wurden neu geladen.")
 
@@ -1142,7 +1199,11 @@ def _bool_from_value(value: Any) -> bool | None:
     return None
 
 
-def _prepare_autotrade_order(alert: Mapping[str, Any], state: BotState) -> tuple[dict[str, Any] | None, str | None]:
+def _prepare_autotrade_order(
+    alert: Mapping[str, Any],
+    state: BotState,
+    snapshot: Mapping[str, Any] | None = None,
+) -> tuple[dict[str, Any] | None, str | None]:
     """Return the BingX order payload for an alert or a failure reason."""
 
     symbol = _extract_symbol_from_alert(alert) or ""
@@ -1224,6 +1285,34 @@ def _prepare_autotrade_order(alert: Mapping[str, Any], state: BotState) -> tuple
         "margin_coin": state.normalised_margin_asset(),
     }
 
+    if snapshot:
+        margin_mode_override = snapshot.get("margin_mode") or snapshot.get("marginType")
+        if isinstance(margin_mode_override, str) and margin_mode_override.strip():
+            mode_token = margin_mode_override.strip().lower()
+            if mode_token.startswith("isol"):
+                payload["margin_mode"] = "ISOLATED"
+            elif mode_token.startswith("cross"):
+                payload["margin_mode"] = "CROSSED"
+            else:
+                payload["margin_mode"] = margin_mode_override.strip().upper()
+
+        margin_coin_override = (
+            snapshot.get("margin_coin")
+            or snapshot.get("marginCoin")
+            or snapshot.get("margin_asset")
+            or snapshot.get("marginAsset")
+        )
+        if isinstance(margin_coin_override, str) and margin_coin_override.strip():
+            payload["margin_coin"] = margin_coin_override.strip().upper()
+
+        leverage_override = snapshot.get("leverage")
+        try:
+            leverage_value = float(leverage_override)
+        except (TypeError, ValueError):
+            leverage_value = None
+        if leverage_value is not None and leverage_value > 0:
+            payload["leverage"] = leverage_value
+
     if price_value is not None and order_type != "MARKET":
         payload["price"] = price_value
     if reduce_only is not None:
@@ -1281,7 +1370,8 @@ async def _execute_autotrade(
     if not isinstance(state, BotState) or not state.autotrade_enabled:
         return
 
-    order_payload, error_message = _prepare_autotrade_order(alert, state)
+    snapshot = load_state_snapshot()
+    order_payload, error_message = _prepare_autotrade_order(alert, state, snapshot)
     if error_message:
         if settings.telegram_chat_id:
             with contextlib.suppress(Exception):
@@ -1365,6 +1455,10 @@ def _build_application(settings: Settings) -> Application:
     application = ApplicationBuilder().token(settings.telegram_bot_token).build()
 
     state = load_state(STATE_FILE)
+    try:
+        export_state_snapshot(state)
+    except Exception:  # pragma: no cover - filesystem issues are logged only
+        LOGGER.exception("Failed to persist state snapshot to %s", STATE_SNAPSHOT_FILE)
     application.bot_data["state"] = state
     application.bot_data["state_file"] = STATE_FILE
 

--- a/state.json
+++ b/state.json
@@ -1,0 +1,10 @@
+{
+  "autotrade_enabled": false,
+  "daily_report_time": "21:00",
+  "last_symbol": null,
+  "leverage": 1.0,
+  "margin_asset": "USDT",
+  "margin_coin": "USDT",
+  "margin_mode": "CROSSED",
+  "max_trade_size": null
+}

--- a/tests/test_autotrade.py
+++ b/tests/test_autotrade.py
@@ -130,6 +130,21 @@ def test_prepare_autotrade_order_uses_state_margin_and_leverage() -> None:
     assert payload["quantity"] == 0.01
 
 
+def test_prepare_autotrade_order_prefers_snapshot_over_state() -> None:
+    """Persisted snapshot overrides ensure BingX receives up-to-date config."""
+
+    state = BotState(autotrade_enabled=True, margin_mode="cross", margin_asset="usdt", leverage=3)
+    snapshot = {"margin_mode": "isolated", "margin_coin": "busd", "leverage": "12"}
+
+    payload, error = _prepare_autotrade_order(make_alert(), state, snapshot)
+
+    assert error is None
+    assert payload is not None
+    assert payload["margin_mode"] == "ISOLATED"
+    assert payload["leverage"] == 12
+    assert payload["margin_coin"] == "BUSD"
+
+
 def test_extract_symbol_from_strategy_block() -> None:
     """Symbols können aus dem Strategy-Block extrahiert werden."""
 

--- a/tests/test_command_parsing.py
+++ b/tests/test_command_parsing.py
@@ -1,0 +1,72 @@
+"""Tests for Telegram command argument parsing helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from bot.telegram_bot import (
+    CommandUsageError,
+    _parse_leverage_command_args,
+    _parse_margin_command_args,
+)
+
+
+@pytest.mark.parametrize(
+    "args,expected",
+    [
+        (("BTCUSDT", "cross", "USDT"), ("BTCUSDT", True, "cross", "USDT")),
+        (("BTCUSDT", "USDT", "isolated"), ("BTCUSDT", True, "isolated", "USDT")),
+        (("cross", "USDT"), (None, False, "cross", "USDT")),
+        (("USDT", "isolated"), ("USDT", True, "isolated", None)),
+    ],
+)
+def test_parse_margin_command_args_handles_flexible_order(args, expected) -> None:
+    """Margin parser accepts symbol/coin in any position."""
+
+    result = _parse_margin_command_args(args)
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    "args",
+    [(), ("BTCUSDT",), ("BTCUSDT", "coin")],
+)
+def test_parse_margin_command_args_rejects_invalid_payload(args) -> None:
+    """Invalid margin command payloads raise ``CommandUsageError``."""
+
+    with pytest.raises(CommandUsageError):
+        _parse_margin_command_args(args)
+
+
+@pytest.mark.parametrize(
+    "args,expected",
+    [
+        (("BTCUSDT", "10", "USDT"), ("BTCUSDT", True, 10.0, "USDT")),
+        (("BTCUSDT", "USDT", "10"), ("BTCUSDT", True, 10.0, "USDT")),
+        (("10", "BTCUSDT", "USDT"), ("BTCUSDT", True, 10.0, "USDT")),
+        (("10", "USDT"), (None, False, 10.0, "USDT")),
+    ],
+)
+def test_parse_leverage_command_args_identifies_components(args, expected) -> None:
+    """Leverage parser finds leverage, symbol and optional margin coin."""
+
+    result = _parse_leverage_command_args(args)
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    "args",
+    [(), ("BTCUSDT", "coin"), ("BTCUSDT", "USDT")],
+)
+def test_parse_leverage_command_args_requires_numeric_value(args) -> None:
+    """Leverage parser raises ``CommandUsageError`` without a numeric value."""
+
+    with pytest.raises(CommandUsageError):
+        _parse_leverage_command_args(args)
+
+
+def test_parse_leverage_command_args_rejects_non_positive_values() -> None:
+    """Leverage must be strictly positive."""
+
+    with pytest.raises(CommandUsageError):
+        _parse_leverage_command_args(("BTCUSDT", "0"))

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,6 +1,8 @@
 """Tests for the persistent bot state helpers."""
 
-from bot.state import BotState
+import json
+
+from bot.state import BotState, export_state_snapshot, load_state_snapshot
 
 
 def test_bot_state_to_dict_uppercases_last_symbol() -> None:
@@ -39,3 +41,46 @@ def test_bot_state_from_mapping_defaults_margin_asset() -> None:
     state = BotState.from_mapping({})
 
     assert state.normalised_margin_asset() == "USDT"
+
+
+def test_export_state_snapshot_contains_normalised_values(tmp_path) -> None:
+    """Snapshots expose the normalised margin and leverage configuration."""
+
+    state = BotState(
+        autotrade_enabled=True,
+        margin_mode="isolated",
+        margin_asset="busd",
+        leverage=12,
+        max_trade_size=25.5,
+        daily_report_time="18:30",
+        last_symbol="ethusdt",
+    )
+
+    snapshot_path = tmp_path / "state.json"
+    export_state_snapshot(state, path=snapshot_path)
+
+    payload = json.loads(snapshot_path.read_text(encoding="utf-8"))
+
+    assert payload["autotrade_enabled"] is True
+    assert payload["margin_mode"] == "ISOLATED"
+    assert payload["margin_coin"] == "BUSD"
+    assert payload["leverage"] == 12
+    assert payload["max_trade_size"] == 25.5
+    assert payload["daily_report_time"] == "18:30"
+    assert payload["last_symbol"] == "ETHUSDT"
+
+
+def test_load_state_snapshot_reads_written_payload(tmp_path) -> None:
+    """Snapshots can be reloaded from disk for downstream consumers."""
+
+    payload = {
+        "autotrade_enabled": True,
+        "margin_mode": "ISOLATED",
+        "margin_coin": "USDT",
+        "leverage": 5,
+    }
+
+    snapshot_path = tmp_path / "state.json"
+    snapshot_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    assert load_state_snapshot(path=snapshot_path) == payload


### PR DESCRIPTION
## Summary
- add a helper to reload the exported runtime configuration from `state.json`
- ensure autotrade orders consult the snapshot so margin coin, mode, and leverage stay in sync with the persisted state
- seed the repository with a default `state.json` and extend tests to cover the snapshot loader and overrides

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e3d64720d8832d88243b1e88a43a36