### PR TITLE
Stop implicit symbol fallback for margin and leverage updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,10 +82,9 @@ When the bot starts it logs its initialization status and exposes the following 
 - `/status` – Confirms that the bot is online.
 - `/help` – Lists available commands.
 - `/report` – Shows an overview of your BingX balance and open positions.
-- `/margin` – Retrieves the latest margin breakdown from BingX.
-- `/leverage` – Displays leverage details for currently open positions.
-- `/set_margin [Symbol] <cross|isolated> [Coin]` – Stores the desired margin mode/coin and updates BingX when possible.
-- `/set_leverage [Symbol] <Wert>` – Sets the leverage for autotrade orders and syncs it to BingX when credentials are present.
+- `/margin [Symbol] <cross|isolated> [Coin]` – Shows the current futures margin overview and updates BingX when arguments are provided.
+- `/leverage [Symbol] <Wert> [Coin]` – Displays the configured leverage or updates it for the selected futures symbol.
+- `/set_margin` and `/set_leverage` remain available as aliases of the commands above.
 
 Financial commands require valid BingX API credentials. If credentials are missing, the bot replies with a helpful reminder.
 

--- a/tests/test_bingx_client.py
+++ b/tests/test_bingx_client.py
@@ -103,7 +103,7 @@ def test_set_margin_type_uses_margin_coin(monkeypatch) -> None:
 
     assert captured["method"] == "POST"
     assert captured["paths"][0] == "/openApi/swap/v3/user/marginType"
-    assert captured["params"]["symbol"] == "BTCUSDT"
+    assert captured["params"]["symbol"] == "BTC-USDT"
     assert captured["params"]["marginType"] == "ISOLATED"
     assert captured["params"]["marginCoin"] == "USDT"
 
@@ -133,7 +133,18 @@ def test_set_leverage_forwards_optional_arguments(monkeypatch) -> None:
 
     assert captured["method"] == "POST"
     assert captured["paths"][0] == "/openApi/swap/v3/user/leverage"
-    assert captured["params"]["symbol"] == "ETHUSDT"
+    assert captured["params"]["symbol"] == "ETH-USDT"
     assert captured["params"]["leverage"] == 7.5
     assert captured["params"]["marginType"] == "ISOLATED"
     assert captured["params"]["marginCoin"] == "USDT"
+
+
+def test_symbol_normalisation_handles_common_formats() -> None:
+    """Symbols are coerced into BingX' futures notation."""
+
+    client = BingXClient(api_key="key", api_secret="secret")
+
+    assert client._normalise_symbol("btcusdt") == "BTC-USDT"
+    assert client._normalise_symbol("BINANCE:ethusdt") == "ETH-USDT"
+    assert client._normalise_symbol("xrp/usdt") == "XRP-USDT"
+    assert client._normalise_symbol("ada_usdc") == "ADA-USDC"


### PR DESCRIPTION
## Summary
- stop reusing the last traded symbol when applying `/margin` or `/leverage` updates so that changes without a symbol stay global
- clarify the bot responses to explain that BingX is only updated when an explicit symbol is supplied
- allow callers to opt out of falling back to the stored symbol when resolving command arguments

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e3eb892390832da247f85abb797b38