### PR TITLE
Increase BingX recvWindow and stabilise signing

### DIFF
--- a/integrations/bingx_client.py
+++ b/integrations/bingx_client.py
@@ -7,6 +7,7 @@ import hmac
 import time
 from dataclasses import dataclass, field
 from typing import Any, Mapping, MutableMapping
+from urllib.parse import quote, urlencode
 
 import httpx
 
@@ -23,6 +24,7 @@ class BingXClient:
     api_secret: str
     base_url: str = "https://open-api.bingx.com"
     timeout: float = 10.0
+    recv_window: int | None = 30_000
     _client: httpx.AsyncClient | None = field(default=None, init=False, repr=False)
 
     async def __aenter__(self) -> "BingXClient":
@@ -225,10 +227,14 @@ class BingXClient:
                 "HTTP client not initialised. Use 'async with BingXClient(...)' when calling the API."
             )
 
-        signed_params = self._sign_parameters(params)
+        query_string = self._sign_parameters(params)
         headers = {"X-BX-APIKEY": self.api_key}
 
-        response = await self._client.request(method, path, params=signed_params, headers=headers)
+        url = path
+        if query_string:
+            url = f"{path}?{query_string}"
+
+        response = await self._client.request(method, url, headers=headers)
 
         try:
             payload = response.json()
@@ -295,21 +301,44 @@ class BingXClient:
         message = str(error).lower()
         return "100400" in message and "api" in message and "not exist" in message
 
-    def _sign_parameters(self, params: Mapping[str, Any] | None) -> MutableMapping[str, Any]:
-        """Return parameters with the BingX HMAC SHA256 signature attached."""
+    def _sign_parameters(self, params: Mapping[str, Any] | None) -> str:
+        """Return the canonical query string with an attached HMAC signature."""
 
-        payload: MutableMapping[str, Any] = dict(params or {})
-        timestamp = payload.get("timestamp") or str(int(time.time() * 1000))
-        payload["timestamp"] = timestamp
+        def _stringify(value: Any) -> str:
+            if isinstance(value, bool):
+                return "true" if value else "false"
+            if isinstance(value, float):
+                formatted = f"{value:.16f}".rstrip("0").rstrip(".")
+                return formatted or "0"
+            return str(value)
 
-        canonical_query = "&".join(f"{key}={payload[key]}" for key in sorted(payload))
+        payload: dict[str, str] = {
+            str(key): _stringify(value)
+            for key, value in (params or {}).items()
+            if value is not None
+        }
+
+        if "timestamp" not in payload:
+            payload["timestamp"] = _stringify(int(time.time() * 1000))
+
+        if "recvWindow" not in payload and self.recv_window:
+            payload["recvWindow"] = _stringify(self.recv_window)
+
+        sorted_items = sorted(payload.items())
+
+        canonical_query = urlencode(
+            sorted_items,
+            safe="-_.~",
+            quote_via=quote,
+        )
+
         signature = hmac.new(
             self.api_secret.encode("utf-8"),
             canonical_query.encode("utf-8"),
             hashlib.sha256,
         ).hexdigest()
-        payload["signature"] = signature
-        return payload
+
+        return f"{canonical_query}&signature={signature}"
 
 
 __all__ = ["BingXClient", "BingXClientError"]

--- a/tests/test_bingx_client.py
+++ b/tests/test_bingx_client.py
@@ -148,3 +148,49 @@ def test_symbol_normalisation_handles_common_formats() -> None:
     assert client._normalise_symbol("BINANCE:ethusdt") == "ETH-USDT"
     assert client._normalise_symbol("xrp/usdt") == "XRP-USDT"
     assert client._normalise_symbol("ada_usdc") == "ADA-USDC"
+
+
+def test_sign_parameters_encodes_and_signs_complex_values(monkeypatch) -> None:
+    """Special characters are percent encoded before signature creation."""
+
+    client = BingXClient(api_key="key", api_secret="secret")
+
+    monkeypatch.setattr(
+        "integrations.bingx_client.time.time", lambda: 1700000000.123
+    )
+
+    query_string = client._sign_parameters(
+        {
+            "symbol": "LTC-USDT",
+            "side": "BUY",
+            "type": "MARKET",
+            "quantity": 1.25,
+            "clientOrderId": "tv:abc def",
+            "reduceOnly": True,
+        }
+    )
+
+    assert (
+        query_string
+        == "clientOrderId=tv%3Aabc%20def&quantity=1.25&recvWindow=30000&reduceOnly=true&"
+        "side=BUY&symbol=LTC-USDT&timestamp=1700000000123&type=MARKET&signature="
+        "41ba7af5085c160a22bf9544d52403d27a3ff6435943414a77aec1f5966173fc"
+    )
+
+
+def test_sign_parameters_respects_custom_recv_window(monkeypatch) -> None:
+    """A custom recvWindow is injected unless already provided."""
+
+    client = BingXClient(api_key="key", api_secret="secret", recv_window=45_000)
+
+    monkeypatch.setattr(
+        "integrations.bingx_client.time.time", lambda: 1700000000.0
+    )
+
+    query_string = client._sign_parameters({"symbol": "BTC-USDT"})
+
+    assert (
+        query_string
+        == "recvWindow=45000&symbol=BTC-USDT&timestamp=1700000000000&signature="
+        "0484e5f598c740a4684cc7eb0ddef70bcce42eee90b4154d18291ed5790a3d9c"
+    )


### PR DESCRIPTION
## Summary
- add a configurable recvWindow defaulting to 30s so signed requests tolerate clock skew
- normalise signing by stringifying parameters upfront and reusing the canonical query string for transmission
- extend the BingX client tests with coverage for the injected recvWindow and updated signature expectations

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e416a8323c832db04fa31a920c33e3