### PR TITLE
Add positionSide handling to BingX autotrade orders

### DIFF
--- a/integrations/bingx_client.py
+++ b/integrations/bingx_client.py
@@ -134,6 +134,7 @@ class BingXClient:
         *,
         symbol: str,
         side: str,
+        position_side: str | None = None,
         quantity: float,
         order_type: str = "MARKET",
         price: float | None = None,
@@ -152,6 +153,8 @@ class BingXClient:
             "quantity": quantity,
         }
 
+        if position_side is not None:
+            params["positionSide"] = position_side
         if price is not None:
             params["price"] = price
         if margin_mode is not None:


### PR DESCRIPTION
## Summary
- infer the BingX positionSide for autotrade payloads, respecting alert overrides and reduce-only trades
- forward the inferred positionSide through the BingX client so swap orders include the required parameter
- extend autotrade tests to cover the new position side behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e422374cf4832d84809f49ee73fd23