### PR TITLE
Filter USDC balances from report output

### DIFF
--- a/tests/test_autotrade.py
+++ b/tests/test_autotrade.py
@@ -173,6 +173,32 @@ def test_prepare_autotrade_order_flips_position_side_when_reducing() -> None:
     assert payload["position_side"] == "LONG"
 
 
+def test_prepare_autotrade_order_respects_long_only_setting() -> None:
+    """Long-only configuration skips short signals."""
+
+    state = BotState(autotrade_enabled=True, autotrade_direction="long")
+    alert = make_alert(side="sell")
+
+    payload, error = _prepare_autotrade_order(alert, state)
+
+    assert payload is None
+    assert error is not None
+    assert "Nur Long" in error
+
+
+def test_prepare_autotrade_order_respects_short_only_setting() -> None:
+    """Short-only configuration skips long signals."""
+
+    state = BotState(autotrade_enabled=True, autotrade_direction="short")
+    alert = make_alert(side="buy")
+
+    payload, error = _prepare_autotrade_order(alert, state)
+
+    assert payload is None
+    assert error is not None
+    assert "Nur Short" in error
+
+
 def test_extract_symbol_from_strategy_block() -> None:
     """Symbols können aus dem Strategy-Block extrahiert werden."""
 

--- a/tests/test_report_formatting.py
+++ b/tests/test_report_formatting.py
@@ -1,0 +1,28 @@
+"""Tests for report formatting helpers."""
+
+from bot.telegram_bot import _format_balance_payload, _format_margin_payload
+
+
+def test_format_balance_payload_skips_usdc_entries() -> None:
+    payload = [
+        {"currency": "USDT", "equity": 100, "availableMargin": 50},
+        {"currency": "USDC", "equity": 80, "availableMargin": 40},
+    ]
+
+    lines = _format_balance_payload(payload)
+
+    combined = "\n".join(lines)
+    assert "USDC" not in combined
+    assert "USDT" in combined
+
+
+def test_format_margin_payload_skips_usdc_entries() -> None:
+    payload = [
+        {"symbol": "USDT", "availableMargin": 25, "usedMargin": 5},
+        {"symbol": "USDC", "availableMargin": 12, "usedMargin": 3},
+    ]
+
+    message = _format_margin_payload(payload)
+
+    assert "USDC" not in message
+    assert "USDT" in message


### PR DESCRIPTION
## Summary
- hide USDC denominated entries when building the Telegram /report balance and margin sections
- add regression tests that ensure USDC balances are excluded while USDT balances remain visible

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e42650b470832d936a929097c0ad46