### PR TITLE
Ensure margin and leverage settings reach BingX orders

### DIFF
--- a/bot/telegram_bot.py
+++ b/bot/telegram_bot.py
@@ -1730,6 +1730,39 @@ async def _execute_autotrade(
             api_secret=settings.bingx_api_secret or "",
             base_url=settings.bingx_base_url,
         ) as client:
+            margin_mode = order_payload.get("margin_mode")
+            margin_coin = order_payload.get("margin_coin")
+            leverage_value = order_payload.get("leverage")
+
+            if margin_mode:
+                try:
+                    await client.set_margin_type(
+                        symbol=order_payload["symbol"],
+                        margin_mode=margin_mode,
+                        margin_coin=margin_coin,
+                    )
+                except BingXClientError as exc:
+                    LOGGER.warning(
+                        "Failed to synchronise margin configuration for %s: %s",
+                        order_payload["symbol"],
+                        exc,
+                    )
+
+            if leverage_value is not None:
+                try:
+                    await client.set_leverage(
+                        symbol=order_payload["symbol"],
+                        leverage=leverage_value,
+                        margin_mode=margin_mode,
+                        margin_coin=margin_coin,
+                    )
+                except BingXClientError as exc:
+                    LOGGER.warning(
+                        "Failed to synchronise leverage for %s: %s",
+                        order_payload["symbol"],
+                        exc,
+                    )
+
             response = await client.place_order(
                 symbol=order_payload["symbol"],
                 side=order_payload["side"],

--- a/integrations/bingx_client.py
+++ b/integrations/bingx_client.py
@@ -168,7 +168,11 @@ class BingXClient:
         if client_order_id is not None:
             params["clientOrderId"] = client_order_id
 
-        return await self._request("POST", "/openApi/swap/v2/trade/order", params=params)
+        return await self._request_with_fallback(
+            "POST",
+            self._swap_paths("trade/order"),
+            params=params,
+        )
 
     async def set_margin_type(
         self,

--- a/tests/test_autotrade.py
+++ b/tests/test_autotrade.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sys
+import asyncio
 from types import SimpleNamespace
 from typing import Any
 
@@ -90,10 +91,12 @@ if "telegram.ext" not in sys.modules:
 
 from bot.state import BotState
 from bot.telegram_bot import (
+    _execute_autotrade,
     _extract_symbol_from_alert,
     _infer_symbol_from_positions,
     _prepare_autotrade_order,
 )
+from config import Settings
 
 
 def make_alert(**overrides: Any) -> dict[str, Any]:
@@ -197,6 +200,129 @@ def test_prepare_autotrade_order_respects_short_only_setting() -> None:
     assert payload is None
     assert error is not None
     assert "Nur Short" in error
+
+
+def test_execute_autotrade_updates_margin_and_leverage(monkeypatch) -> None:
+    """Autotrade synchronises leverage and margin settings before trading."""
+
+    class DummyBot:
+        async def send_message(self, *args, **kwargs) -> None:
+            return None
+
+    class RecordingClient:
+        def __init__(self, *args, **kwargs) -> None:
+            self.margin_calls: list[dict[str, Any]] = []
+            self.leverage_calls: list[dict[str, Any]] = []
+            self.order_calls: list[dict[str, Any]] = []
+
+        async def __aenter__(self) -> "RecordingClient":
+            instances.append(self)
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        async def set_margin_type(
+            self,
+            *,
+            symbol: str,
+            margin_mode: str,
+            margin_coin: str | None = None,
+        ) -> None:
+            self.margin_calls.append(
+                {
+                    "symbol": symbol,
+                    "margin_mode": margin_mode,
+                    "margin_coin": margin_coin,
+                }
+            )
+
+        async def set_leverage(
+            self,
+            *,
+            symbol: str,
+            leverage: float,
+            margin_mode: str | None = None,
+            margin_coin: str | None = None,
+        ) -> None:
+            self.leverage_calls.append(
+                {
+                    "symbol": symbol,
+                    "leverage": leverage,
+                    "margin_mode": margin_mode,
+                    "margin_coin": margin_coin,
+                }
+            )
+
+        async def place_order(
+            self,
+            *,
+            symbol: str,
+            side: str,
+            position_side: str | None = None,
+            quantity: float,
+            order_type: str = "MARKET",
+            price: float | None = None,
+            margin_mode: str | None = None,
+            margin_coin: str | None = None,
+            leverage: float | None = None,
+            reduce_only: bool | None = None,
+            client_order_id: str | None = None,
+        ) -> dict[str, Any]:
+            self.order_calls.append(
+                {
+                    "symbol": symbol,
+                    "side": side,
+                    "position_side": position_side,
+                    "quantity": quantity,
+                    "order_type": order_type,
+                    "price": price,
+                    "margin_mode": margin_mode,
+                    "margin_coin": margin_coin,
+                    "leverage": leverage,
+                    "reduce_only": reduce_only,
+                    "client_order_id": client_order_id,
+                }
+            )
+            return {"orderId": "1", "status": "FILLED"}
+
+    instances: list[RecordingClient] = []
+
+    monkeypatch.setattr("bot.telegram_bot.BingXClient", RecordingClient)
+    monkeypatch.setattr("bot.telegram_bot.load_state_snapshot", lambda: None)
+
+    state = BotState(
+        autotrade_enabled=True,
+        margin_mode="isolated",
+        margin_asset="busd",
+        leverage=7.5,
+    )
+
+    application = SimpleNamespace(bot=DummyBot(), bot_data={"state": state})
+    settings = Settings(
+        telegram_bot_token="token",
+        bingx_api_key="key",
+        bingx_api_secret="secret",
+    )
+
+    alert = {"symbol": "BTCUSDT", "side": "buy", "quantity": 0.5}
+
+    asyncio.run(_execute_autotrade(application, settings, alert))
+
+    assert instances, "Expected BingXClient to be instantiated"
+    client = instances[0]
+    assert client.margin_calls == [
+        {"symbol": "BTCUSDT", "margin_mode": "ISOLATED", "margin_coin": "BUSD"}
+    ]
+    assert client.leverage_calls == [
+        {
+            "symbol": "BTCUSDT",
+            "leverage": 7.5,
+            "margin_mode": "ISOLATED",
+            "margin_coin": "BUSD",
+        }
+    ]
+    assert client.order_calls and client.order_calls[0]["margin_mode"] == "ISOLATED"
 
 
 def test_extract_symbol_from_strategy_block() -> None:

--- a/tests/test_bingx_client.py
+++ b/tests/test_bingx_client.py
@@ -139,6 +139,39 @@ def test_set_leverage_forwards_optional_arguments(monkeypatch) -> None:
     assert captured["params"]["marginCoin"] == "USDT"
 
 
+def test_place_order_forwards_margin_configuration(monkeypatch) -> None:
+    """Order placement forwards leverage and margin configuration to BingX."""
+
+    client = BingXClient(api_key="key", api_secret="secret")
+    captured: dict[str, Any] = {}
+
+    async def fake_request(self, method, paths, *, params=None):  # type: ignore[override]
+        captured["method"] = method
+        captured["paths"] = paths
+        captured["params"] = params or {}
+        return {"orderId": "1", "status": "FILLED"}
+
+    monkeypatch.setattr(BingXClient, "_request_with_fallback", fake_request)
+
+    asyncio.run(
+        client.place_order(
+            symbol="BTCUSDT",
+            side="BUY",
+            quantity=1.25,
+            margin_mode="ISOLATED",
+            margin_coin="USDT",
+            leverage=12,
+        )
+    )
+
+    assert captured["method"] == "POST"
+    assert captured["paths"][0] == "/openApi/swap/v3/trade/order"
+    assert captured["params"]["symbol"] == "BTC-USDT"
+    assert captured["params"]["marginType"] == "ISOLATED"
+    assert captured["params"]["marginCoin"] == "USDT"
+    assert captured["params"]["leverage"] == 12
+
+
 def test_symbol_normalisation_handles_common_formats() -> None:
     """Symbols are coerced into BingX' futures notation."""
 


### PR DESCRIPTION
## Summary
- call the BingX trade order endpoint through the versioned fallback helper so the newest API accepts margin and leverage parameters
- add a regression test confirming place_order forwards the configured margin type, coin and leverage

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e4a1ec0dd0832da7c8e4c6d13cad53