### PR TITLE
Ignore numeric marginCoin overrides from TradingView alerts

### DIFF
--- a/bot/telegram_bot.py
+++ b/bot/telegram_bot.py
@@ -1635,8 +1635,20 @@ def _prepare_autotrade_order(
             payload["margin_mode"] = token.upper()
 
     def _apply_margin_coin_override(raw_value: Any) -> None:
-        if isinstance(raw_value, str) and raw_value.strip():
-            payload["margin_coin"] = raw_value.strip().upper()
+        if not isinstance(raw_value, str):
+            return
+
+        token = raw_value.strip()
+        if not token:
+            return
+
+        # Ignore payloads that only contain digits. TradingView alerts encode the
+        # margin amount as ``marginCoin = "5"`` which would otherwise override the
+        # configured asset and break the BingX synchronisation calls.
+        if not any(char.isalpha() for char in token):
+            return
+
+        payload["margin_coin"] = token.upper()
 
     def _apply_leverage_override(raw_value: Any) -> None:
         try:

--- a/tests/test_autotrade.py
+++ b/tests/test_autotrade.py
@@ -169,6 +169,24 @@ def test_prepare_autotrade_order_alert_overrides_all_sources() -> None:
     assert payload["leverage"] == 50
 
 
+def test_prepare_autotrade_order_ignores_numeric_margin_coin() -> None:
+    """Numeric marginCoin overrides from TradingView alerts are ignored."""
+
+    state = BotState(
+        autotrade_enabled=True,
+        margin_mode="isolated",
+        margin_asset="usdt",
+        leverage=7.5,
+    )
+    alert = make_alert(marginCoin="5")
+
+    payload, error = _prepare_autotrade_order(alert, state)
+
+    assert error is None
+    assert payload is not None
+    assert payload["margin_coin"] == "USDT"
+
+
 def test_prepare_autotrade_order_respects_position_side_override() -> None:
     """PositionSide aus dem Signal wird direkt übernommen."""
 


### PR DESCRIPTION
## Summary
- ignore numeric TradingView marginCoin overrides so the configured margin asset remains intact when synchronising with BingX
- add an autotrade regression test covering numeric marginCoin payloads from alerts

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e54561b044832d8585540f49cc631d