### PR TITLE
Add signal order placement helpers and global trade config

### DIFF
--- a/integrations/bingx_client.py
+++ b/integrations/bingx_client.py
@@ -6,15 +6,67 @@ import hashlib
 import hmac
 import time
 from dataclasses import dataclass, field
-from decimal import Decimal, InvalidOperation
+from decimal import Decimal, InvalidOperation, ROUND_DOWN
 from typing import Any, Mapping, MutableMapping
 from urllib.parse import quote, urlencode
 
-import httpx
+try:  # pragma: no cover - optional dependency for test environments
+    import httpx
+except ModuleNotFoundError:  # pragma: no cover - fallback for tests without httpx
+    httpx = None  # type: ignore[assignment]
 
 
 class BingXClientError(RuntimeError):
     """Base exception raised when the BingX API returns an error."""
+
+
+def calc_order_qty(
+    price: float,
+    margin_usdt: float,
+    leverage: float,
+    step_size: float,
+    min_qty: float,
+) -> float:
+    """Return a quantity respecting the exchange filters.
+
+    The TradingView alerts configure a *margin_usdt* budget which gets scaled by
+    *leverage*.  BingX enforces a minimum quantity as well as a tick size for the
+    quantity.  The result therefore needs to be rounded down to the next valid
+    tick size while still respecting the minimum quantity.  A :class:`ValueError`
+    is raised if the provided configuration would lead to an invalid order.
+    """
+
+    if price <= 0:
+        raise ValueError("Price must be greater than zero to calculate the order quantity.")
+    if margin_usdt <= 0:
+        raise ValueError("Margin must be greater than zero to calculate the order quantity.")
+    if leverage <= 0:
+        raise ValueError("Leverage must be greater than zero to calculate the order quantity.")
+    if step_size <= 0:
+        raise ValueError("Step size must be greater than zero to calculate the order quantity.")
+    if min_qty < 0:
+        raise ValueError("Minimum quantity cannot be negative.")
+
+    try:
+        price_dec = Decimal(str(price))
+        margin_dec = Decimal(str(margin_usdt))
+        leverage_dec = Decimal(str(leverage))
+        step_dec = Decimal(str(step_size))
+        min_qty_dec = Decimal(str(min_qty))
+    except InvalidOperation as exc:  # pragma: no cover - defensive
+        raise ValueError("Invalid numeric value provided for quantity calculation") from exc
+
+    notional_value = (margin_dec * leverage_dec) / price_dec
+    if notional_value <= 0:
+        raise ValueError("Computed order quantity is not positive.")
+
+    steps = (notional_value / step_dec).to_integral_value(rounding=ROUND_DOWN)
+    quantity = steps * step_dec
+
+    if quantity < min_qty_dec:
+        quantity = min_qty_dec
+
+    return float(quantity)
 
 
 @dataclass
@@ -29,6 +81,9 @@ class BingXClient:
     _client: httpx.AsyncClient | None = field(default=None, init=False, repr=False)
 
     async def __aenter__(self) -> "BingXClient":
+        if httpx is None:  # pragma: no cover - dependency guard for optional install
+            raise BingXClientError("The 'httpx' package is required to use BingXClient")
+
         self._client = httpx.AsyncClient(base_url=self.base_url, timeout=self.timeout)
         return self
 
@@ -129,6 +184,67 @@ class BingXClient:
             params=params,
         )
         return data
+
+    async def get_mark_price(self, symbol: str) -> float:
+        """Return the current mark price for *symbol*."""
+
+        params = {"symbol": self._normalise_symbol(symbol)}
+        payload = await self._request_with_fallback(
+            "GET",
+            self._swap_paths(
+                "market/markPrice",
+                "market/getMarkPrice",
+                "market/price",
+            ),
+            params=params,
+        )
+
+        price = self._extract_float(payload, "price", "markPrice", "mark_price")
+        if price is None:
+            raise BingXClientError(f"Unable to determine mark price for {symbol!r}: {payload!r}")
+
+        return price
+
+    async def get_symbol_filters(self, symbol: str) -> dict[str, float]:
+        """Return quantity filters for *symbol*.
+
+        The structure of the BingX response has changed a few times historically
+        which is why the parser accepts several shapes.  The result always
+        contains ``min_qty`` and ``step_size`` keys.
+        """
+
+        params = {"symbol": self._normalise_symbol(symbol)}
+        payload = await self._request_with_fallback(
+            "GET",
+            self._swap_paths(
+                "market/symbol-config",
+                "market/getSymbol",
+                "market/detail",
+            ),
+            params=params,
+        )
+
+        filters: Mapping[str, Any] | None = None
+        if isinstance(payload, Mapping):
+            if "filters" in payload and isinstance(payload["filters"], Mapping):
+                filters = payload["filters"]
+            elif "data" in payload and isinstance(payload["data"], Mapping):
+                filters = payload["data"]
+        elif isinstance(payload, list) and payload:
+            candidate = payload[0]
+            if isinstance(candidate, Mapping):
+                filters = candidate.get("filters") if isinstance(candidate.get("filters"), Mapping) else candidate
+
+        if not isinstance(filters, Mapping):
+            raise BingXClientError(f"Unexpected filters payload for {symbol!r}: {payload!r}")
+
+        min_qty = self._extract_float(filters, "minQty", "min_qty", "min_quantity")
+        step_size = self._extract_float(filters, "stepSize", "step_size", "qty_step", "qtyStep")
+
+        if min_qty is None or step_size is None:
+            raise BingXClientError(f"Quantity filters missing for {symbol!r}: {filters!r}")
+
+        return {"min_qty": min_qty, "step_size": step_size}
 
     async def place_order(
         self,
@@ -307,6 +423,31 @@ class BingXClient:
             for endpoint in endpoints
             for version in versions
         )
+
+    @staticmethod
+    def _extract_float(payload: Any, *keys: str) -> float | None:
+        """Return the first parsable float from *payload* using *keys*."""
+
+        values: list[Any] = []
+        if isinstance(payload, Mapping):
+            values.extend(payload.get(key) for key in keys if key in payload)
+            nested = payload.get("data")
+            if isinstance(nested, Mapping):
+                values.extend(nested.get(key) for key in keys if key in nested)
+        elif isinstance(payload, list):
+            for item in payload:
+                if isinstance(item, Mapping):
+                    candidate = BingXClient._extract_float(item, *keys)
+                    if candidate is not None:
+                        return candidate
+
+        for value in values:
+            try:
+                return float(value)
+            except (TypeError, ValueError):
+                continue
+
+        return None
 
     @staticmethod
     def _is_missing_api_error(error: BingXClientError) -> bool:

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -1,0 +1,86 @@
+"""Tests for the webhook dispatcher helper utilities."""
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from bot.state import BotState, GlobalTradeConfig
+from integrations.bingx_client import calc_order_qty
+from webhook import dispatcher
+
+
+def test_calc_order_qty_rounds_and_applies_minimum() -> None:
+    """The helper respects exchange step sizes and minimum quantities."""
+
+    quantity = calc_order_qty(
+        price=25_000,
+        margin_usdt=52,
+        leverage=5,
+        step_size=0.001,
+        min_qty=0.002,
+    )
+
+    assert quantity == pytest.approx(0.01)
+
+    quantity_min = calc_order_qty(
+        price=40_000,
+        margin_usdt=5,
+        leverage=1,
+        step_size=0.001,
+        min_qty=0.01,
+    )
+
+    assert quantity_min == pytest.approx(0.01)
+
+
+def test_place_signal_order_executes_market_order() -> None:
+    """Orders are placed using the configured trading context."""
+
+    async def runner() -> None:
+        original_state = dispatcher.state
+        original_client = dispatcher.client
+
+        try:
+            state = BotState(
+                margin_mode="isolated",
+                margin_asset="usdt",
+                global_trade=GlobalTradeConfig(
+                    margin_usdt=100,
+                    lev_long=5,
+                    lev_short=7,
+                    isolated=True,
+                    hedge_mode=True,
+                ),
+            )
+
+            mock_client: AsyncMock = AsyncMock()
+            mock_client.get_mark_price.return_value = 25_000.0
+            mock_client.get_symbol_filters.return_value = {"min_qty": 0.001, "step_size": 0.001}
+            mock_client.place_order.return_value = {"status": "success"}
+
+            dispatcher.configure_trading_context(bot_state=state, bingx_client=mock_client)
+
+            result = await dispatcher.place_signal_order("BTC-USDT", "buy")
+
+            assert result == {"status": "success"}
+            mock_client.set_margin_type.assert_awaited_once_with(
+                symbol="BTC-USDT", margin_mode="ISOLATED", margin_coin="USDT"
+            )
+            mock_client.set_leverage.assert_awaited_once_with(
+                symbol="BTC-USDT",
+                leverage=5,
+                margin_mode="ISOLATED",
+                margin_coin="USDT",
+                side="BUY",
+            )
+            mock_client.place_order.assert_awaited_once()
+            args, kwargs = mock_client.place_order.call_args
+            assert kwargs["position_side"] == "LONG"
+            assert kwargs["order_type"] == "MARKET"
+            assert kwargs["reduce_only"] is False
+        finally:
+            dispatcher.configure_trading_context(bot_state=original_state, bingx_client=original_client)
+
+    asyncio.run(runner())
+

--- a/webhook/dispatcher.py
+++ b/webhook/dispatcher.py
@@ -5,11 +5,43 @@ from __future__ import annotations
 import asyncio
 from typing import Any, Mapping
 
+from bot.state import BotState
+from integrations.bingx_client import BingXClient, calc_order_qty
+
 AlertPayload = Mapping[str, Any]
 
 _ALERT_QUEUE: asyncio.Queue[AlertPayload] = asyncio.Queue()
 
+#
+# Trading context -----------------------------------------------------------
+#
+# These globals are configured by the Telegram bot when the webhook handling
+# is initialised.  They are kept deliberately simple so that the dispatcher can
+# be unit-tested in isolation by injecting lightweight fakes.
+state: BotState = BotState()
+client: BingXClient | None = None
 
+
+def configure_trading_context(
+    *, bot_state: BotState | None = None, bingx_client: BingXClient | None = None
+) -> None:
+    """Update the trading context used for auto-orders.
+
+    Parameters may be omitted to keep the existing values which is convenient
+    for tests patching only a subset of the dependencies.
+    """
+
+    global state, client
+
+    if bot_state is not None:
+        state = bot_state
+    if bingx_client is not None:
+        client = bingx_client
+
+
+# ---------------------------------------------------------------------------
+# Alert queue helpers
+# ---------------------------------------------------------------------------
 def get_alert_queue() -> asyncio.Queue[AlertPayload]:
     """Return the shared asyncio queue for TradingView alerts."""
 
@@ -22,4 +54,97 @@ async def publish_alert(alert: AlertPayload) -> None:
     await _ALERT_QUEUE.put(alert)
 
 
-__all__ = ["AlertPayload", "get_alert_queue", "publish_alert"]
+# ---------------------------------------------------------------------------
+# Trading helpers
+# ---------------------------------------------------------------------------
+async def place_signal_order(symbol: str, side: str) -> Any:
+    """Execute a market order for a TradingView signal.
+
+    The order size is calculated based on the configured *margin_usdt* budget
+    and leverage for the requested direction.  Margin mode and leverage are
+    synchronised with BingX before submitting the order.  ``side`` must be one
+    of ``"BUY"`` or ``"SELL"`` (case insensitive).
+    """
+
+    if client is None:
+        raise RuntimeError("BingX client is not configured for order placement.")
+
+    cfg = getattr(state, "global_trade", None)
+    if cfg is None:
+        raise RuntimeError("Global trade configuration missing on bot state.")
+
+    side_token = side.strip().upper()
+    if side_token not in {"BUY", "SELL"}:
+        raise ValueError("Order side must be either 'BUY' or 'SELL'.")
+
+    margin_mode = "ISOLATED" if getattr(cfg, "isolated", False) else "CROSSED"
+    margin_coin = state.normalised_margin_asset()
+    hedge_mode = bool(getattr(cfg, "hedge_mode", False))
+
+    # 1) Configure margin mode and leverage on the exchange.
+    await client.set_margin_type(symbol=symbol, margin_mode=margin_mode, margin_coin=margin_coin)
+
+    leverage = (
+        getattr(cfg, "lev_long", None)
+        if side_token == "BUY"
+        else getattr(cfg, "lev_short", None)
+    )
+    if leverage is None:
+        raise RuntimeError("Leverage configuration missing for the requested direction.")
+
+    leverage_kwargs: dict[str, Any] = {
+        "symbol": symbol,
+        "leverage": leverage,
+        "margin_mode": margin_mode,
+        "margin_coin": margin_coin,
+    }
+    if hedge_mode:
+        leverage_kwargs["side"] = side_token
+
+    await client.set_leverage(**leverage_kwargs)
+
+    # 2) Fetch latest price and exchange filters.
+    price = await client.get_mark_price(symbol)
+    filters = await client.get_symbol_filters(symbol)
+
+    step_size = float(
+        filters.get("step_size")
+        or filters.get("stepSize")
+        or filters.get("qty_step")
+        or filters.get("qtyStep")
+        or 0.0
+    )
+    min_qty = float(filters.get("min_qty") or filters.get("minQty") or 0.0)
+    if step_size <= 0:
+        raise RuntimeError("Exchange did not provide a valid quantity step size.")
+
+    # 3) Calculate the order quantity respecting leverage and filters.
+    margin_budget = getattr(cfg, "margin_usdt", None)
+    if margin_budget is None:
+        raise RuntimeError("Margin budget missing from global trade configuration.")
+
+    quantity = calc_order_qty(price, margin_budget, leverage, step_size, min_qty)
+
+    # 4) Submit the market order on BingX.
+    order_kwargs: dict[str, Any] = {
+        "symbol": symbol,
+        "side": side_token,
+        "quantity": quantity,
+        "order_type": "MARKET",
+        "reduce_only": False,
+    }
+    if hedge_mode:
+        order_kwargs["position_side"] = "LONG" if side_token == "BUY" else "SHORT"
+
+    return await client.place_order(**order_kwargs)
+
+
+__all__ = [
+    "AlertPayload",
+    "client",
+    "configure_trading_context",
+    "get_alert_queue",
+    "place_signal_order",
+    "publish_alert",
+    "state",
+]


### PR DESCRIPTION
## Summary
- add a reusable global trading configuration to the bot state and snapshot export
- extend the BingX client with quantity calculation, price/filter helpers, and optional httpx usage
- update the webhook dispatcher to place market orders using the configured trading context and add unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e55f3bfc50832dba96512cc3acd8c6