### PR TITLE
Align autotrade leverage and margin handling with new config

### DIFF
--- a/bot/telegram_bot.py
+++ b/bot/telegram_bot.py
@@ -2004,97 +2004,119 @@ async def _execute_autotrade(
             api_secret=settings.bingx_api_secret or "",
             base_url=settings.bingx_base_url,
         ) as client:
-            margin_mode = order_payload.get("margin_mode")
-            margin_coin = order_payload.get("margin_coin")
-            leverage_value = order_payload.get("leverage")
+            cfg = state_for_order.global_trade
+            margin_coin = state_for_order.normalised_margin_asset()
+            margin_mode = "ISOLATED" if cfg.isolated else "CROSSED"
+            side_token = order_payload["side"].upper()
+            order_payload["side"] = side_token
 
-            if margin_mode:
-                try:
-                    await client.set_margin_type(
-                        symbol=order_payload["symbol"],
-                        margin_mode=margin_mode,
-                        margin_coin=margin_coin,
-                    )
-                except BingXClientError as exc:
-                    LOGGER.warning(
-                        "Failed to synchronise margin configuration for %s: %s",
-                        order_payload["symbol"],
-                        exc,
-                    )
+            lev_long = int(cfg.lev_long) if cfg.lev_long else 1
+            lev_long = max(1, lev_long)
+            lev_short = int(cfg.lev_short) if cfg.lev_short else lev_long
+            lev_short = max(1, lev_short)
+            leverage_for_side = lev_long if side_token == "BUY" else lev_short
 
-            if leverage_value is not None:
-                try:
-                    await client.set_leverage(
-                        symbol=order_payload["symbol"],
-                        leverage=leverage_value,
-                        margin_mode=margin_mode,
-                        margin_coin=margin_coin,
-                        side=order_payload.get("side"),
-                        position_side=order_payload.get("position_side"),
-                    )
-                except BingXClientError as exc:
-                    LOGGER.warning(
-                        "Failed to synchronise leverage for %s: %s",
-                        order_payload["symbol"],
-                        exc,
-                    )
+            order_payload["margin_mode"] = margin_mode
+            order_payload["margin_coin"] = margin_coin
+            order_payload["leverage"] = leverage_for_side
+            order_payload["margin_usdt"] = float(cfg.margin_usdt)
 
-            quantity_for_order = order_payload.get("quantity")
-            margin_budget = order_payload.get("margin_usdt")
+            if cfg.hedge_mode:
+                position_side = "LONG" if side_token == "BUY" else "SHORT"
+            else:
+                position_side = None
+            order_payload["position_side"] = position_side
 
-            if (
-                (quantity_for_order is None or quantity_for_order <= 0)
-                and margin_budget is not None
-            ):
-                leverage_for_calc = order_payload.get("leverage")
-                if leverage_for_calc is None or leverage_for_calc <= 0:
-                    raise BingXClientError(
-                        "Autotrade-Konfiguration enthält keinen gültigen Leverage-Wert für Margin-Berechnung."
-                    )
-
-                price = await client.get_mark_price(order_payload["symbol"])
-                filters = await client.get_symbol_filters(order_payload["symbol"])
-                step_size = float(
-                    filters.get("step_size")
-                    or filters.get("stepSize")
-                    or filters.get("qty_step")
-                    or filters.get("qtyStep")
-                    or 0.0
+            try:
+                await client.set_position_mode(cfg.hedge_mode)
+            except BingXClientError as exc:
+                LOGGER.warning(
+                    "Failed to update position mode for %s: %s",
+                    order_payload["symbol"],
+                    exc,
                 )
-                min_qty = float(filters.get("min_qty") or filters.get("minQty") or 0.0)
-                if step_size <= 0:
-                    raise BingXClientError(
-                        f"BingX lieferte keinen gültigen step_size-Filter für {order_payload['symbol']}"
-                    )
 
-                try:
-                    quantity_for_order = calc_order_qty(
-                        price,
-                        float(margin_budget),
-                        float(leverage_for_calc),
-                        step_size,
-                        min_qty,
-                    )
-                except ValueError as exc:
-                    raise BingXClientError(
-                        f"Ordergröße konnte aus Margin nicht berechnet werden: {exc}"
-                    ) from exc
+            try:
+                await client.set_margin_type(
+                    symbol=order_payload["symbol"],
+                    isolated=cfg.isolated,
+                    margin_coin=margin_coin,
+                )
+            except BingXClientError as exc:
+                LOGGER.warning(
+                    "Failed to synchronise margin configuration for %s: %s",
+                    order_payload["symbol"],
+                    exc,
+                )
 
-                order_payload["quantity"] = quantity_for_order
+            try:
+                await client.set_leverage(
+                    symbol=order_payload["symbol"],
+                    lev_long=lev_long,
+                    lev_short=lev_short,
+                    hedge=cfg.hedge_mode,
+                    margin_coin=margin_coin,
+                )
+            except BingXClientError as exc:
+                LOGGER.warning(
+                    "Failed to synchronise leverage for %s: %s",
+                    order_payload["symbol"],
+                    exc,
+                )
 
-            if quantity_for_order is None or quantity_for_order <= 0:
-                raise BingXClientError("Autotrade-Konfiguration liefert keine gültige Positionsgröße.")
+            price = await client.get_mark_price(order_payload["symbol"])
+            filters = await client.get_symbol_filters(order_payload["symbol"])
+            step_size = float(
+                filters.get("step_size")
+                or filters.get("stepSize")
+                or filters.get("qty_step")
+                or filters.get("qtyStep")
+                or 0.0
+            )
+            min_qty = float(filters.get("min_qty") or filters.get("minQty") or 0.0)
+            min_notional_raw = (
+                filters.get("min_notional")
+                or filters.get("minNotional")
+                or filters.get("notional")
+            )
+
+            if step_size <= 0:
+                raise BingXClientError(
+                    f"BingX lieferte keinen gültigen step_size-Filter für {order_payload['symbol']}"
+                )
+
+            margin_budget = float(order_payload.get("margin_usdt", 0.0))
+            if margin_budget <= 0:
+                raise BingXClientError(
+                    "Autotrade-Konfiguration enthält keinen gültigen Margin-Wert."
+                )
+
+            try:
+                quantity_for_order = calc_order_qty(
+                    price=price,
+                    margin_usdt=margin_budget,
+                    leverage=int(leverage_for_side),
+                    step_size=step_size,
+                    min_qty=min_qty,
+                    min_notional=float(min_notional_raw) if min_notional_raw else None,
+                )
+            except ValueError as exc:
+                raise BingXClientError(
+                    f"Ordergröße konnte aus Margin nicht berechnet werden: {exc}"
+                ) from exc
+
+            order_payload["quantity"] = quantity_for_order
 
             response = await client.place_order(
                 symbol=order_payload["symbol"],
                 side=order_payload["side"],
-                position_side=order_payload.get("position_side"),
+                position_side=position_side,
                 quantity=quantity_for_order,
                 order_type=order_payload.get("order_type", "MARKET"),
                 price=order_payload.get("price"),
-                margin_mode=order_payload.get("margin_mode"),
-                margin_coin=order_payload.get("margin_coin"),
-                leverage=order_payload.get("leverage"),
+                margin_mode=margin_mode,
+                margin_coin=margin_coin,
+                leverage=leverage_for_side,
                 reduce_only=order_payload.get("reduce_only"),
                 client_order_id=order_payload.get("client_order_id"),
             )


### PR DESCRIPTION
## Summary
- compute BingX order quantities from margin and leverage while respecting step, min qty, and min notional filters
- explicitly sync position mode, margin type, and leverage from the global trade configuration before autotrade orders
- update webhook helpers and tests to cover the new exchange synchronisation flow and error handling

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68e687ec735c832dabf5ec36ad5c34d1